### PR TITLE
Mobilni redizajn naslovne strane Novog Talasa

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -17,9 +17,9 @@ const navItems = [
 
 function MastheadLogo({ isDark }: { isDark: boolean }) {
   return (
-    <Link href="/" className="flex items-center justify-center gap-0 no-underline whitespace-nowrap">
+    <Link href="/" className="flex items-center justify-center gap-0 no-underline whitespace-nowrap max-w-full overflow-hidden">
       <span
-        className="font-extrabold tracking-[0.19em] uppercase text-[24px] min-[390px]:text-[25px] md:text-[22px]"
+        className="font-extrabold tracking-[0.13em] min-[390px]:tracking-[0.16em] uppercase text-[21px] min-[390px]:text-[23px] md:text-[22px]"
         style={{
           fontFamily: "'Lora', serif",
           color: isDark ? "#f6f3e8" : "#1a2a3a",
@@ -28,7 +28,7 @@ function MastheadLogo({ isDark }: { isDark: boolean }) {
         NOVI{" "}
       </span>
       <span
-        className="font-extrabold tracking-[0.19em] uppercase text-[24px] min-[390px]:text-[25px] md:text-[22px]"
+        className="font-extrabold tracking-[0.13em] min-[390px]:tracking-[0.16em] uppercase text-[21px] min-[390px]:text-[23px] md:text-[22px]"
         style={{
           fontFamily: "'Lora', serif",
           color: isDark ? "#d9bf7a" : "#8B0000",
@@ -42,22 +42,22 @@ function MastheadLogo({ isDark }: { isDark: boolean }) {
 
 function MobileWaveDivider({ isDark }: { isDark: boolean }) {
   return (
-    <div className="lg:hidden px-9 pb-2">
-      <div className="relative h-[12px] flex items-center justify-center">
+    <div className="lg:hidden px-8 pb-2">
+      <div className="relative h-[12px] flex items-center justify-center max-w-[290px] mx-auto">
         <div
           className="absolute left-0 right-0 h-px"
           style={{ backgroundColor: isDark ? "rgba(217,191,122,0.45)" : "rgba(139,0,0,0.42)" }}
         />
         <svg
           viewBox="0 0 120 24"
-          className="relative w-[66px] h-[16px]"
+          className="relative w-[58px] h-[15px]"
           aria-hidden="true"
         >
           <path
             d="M2 12 H38 C42 12 42 7 45 7 C49 7 48 18 52 18 C57 18 55 4 60 4 C65 4 63 20 68 20 C72 20 72 12 78 12 H118"
             fill="none"
             stroke={isDark ? "#d9bf7a" : "#8B0000"}
-            strokeWidth="2.2"
+            strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
@@ -74,7 +74,7 @@ export default function Header() {
 
   return (
     <header
-      className="sticky top-0 z-50 transition-colors duration-300"
+      className="sticky top-0 z-50 transition-colors duration-300 overflow-hidden"
       style={{
         backgroundColor: isDark ? "#0d0d0f" : "#ffffff",
         borderBottom: isDark
@@ -106,10 +106,10 @@ export default function Header() {
             className="absolute left-0 lg:hidden p-1"
             style={{ color: isDark ? "#c9c6cf" : "#1a2a3a" }}
           >
-            {mobileOpen ? <X size={26} /> : <Menu size={26} />}
+            {mobileOpen ? <X size={25} /> : <Menu size={25} />}
           </button>
 
-          <div className="flex flex-col items-center justify-center max-w-[230px] min-[390px]:max-w-none">
+          <div className="flex flex-col items-center justify-center w-[calc(100%-118px)] max-w-[245px] min-[390px]:max-w-[270px] mx-auto">
             <MastheadLogo isDark={isDark} />
             <p
               className="lg:hidden mt-1 text-[15px] italic leading-none whitespace-nowrap"
@@ -174,14 +174,14 @@ export default function Header() {
               }}
               aria-label={isDark ? "Svetli režim" : "Tamni režim"}
             >
-              {isDark ? <Sun size={19} /> : <Moon size={19} />}
+              {isDark ? <Sun size={18} /> : <Moon size={18} />}
             </button>
             <button
-              className="p-1"
+              className="p-1 hidden min-[360px]:block"
               style={{ color: isDark ? "#c9c6cf" : "#1a2a3a" }}
               aria-label="Pretraga"
             >
-              <Search size={24} />
+              <Search size={23} />
             </button>
           </div>
         </div>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,8 +1,3 @@
-/*
- * DESIGN: "Diplomatska Klasika" — Foreign Affairs-inspired header
- * Mobile update: centered Novi Talas masthead, one-line tagline and red wave divider.
- */
-
 import { useState } from "react";
 import { Link } from "wouter";
 import { Menu, X, Sun, Moon, Search } from "lucide-react";
@@ -20,19 +15,13 @@ function MastheadLogo({ isDark }: { isDark: boolean }) {
     <Link href="/" className="flex items-center justify-center gap-0 no-underline whitespace-nowrap max-w-full overflow-hidden">
       <span
         className="font-extrabold tracking-[0.13em] min-[390px]:tracking-[0.16em] uppercase text-[21px] min-[390px]:text-[23px] md:text-[22px]"
-        style={{
-          fontFamily: "'Lora', serif",
-          color: isDark ? "#f6f3e8" : "#1a2a3a",
-        }}
+        style={{ fontFamily: "'Lora', serif", color: isDark ? "#f6f3e8" : "#1a2a3a" }}
       >
         NOVI{" "}
       </span>
       <span
         className="font-extrabold tracking-[0.13em] min-[390px]:tracking-[0.16em] uppercase text-[21px] min-[390px]:text-[23px] md:text-[22px]"
-        style={{
-          fontFamily: "'Lora', serif",
-          color: isDark ? "#d9bf7a" : "#8B0000",
-        }}
+        style={{ fontFamily: "'Lora', serif", color: isDark ? "#d9bf7a" : "#8B0000" }}
       >
         TALAS
       </span>
@@ -41,27 +30,24 @@ function MastheadLogo({ isDark }: { isDark: boolean }) {
 }
 
 function MobileWaveDivider({ isDark }: { isDark: boolean }) {
+  const lineColor = isDark ? "rgba(217,191,122,0.45)" : "rgba(139,0,0,0.42)";
+  const waveColor = isDark ? "#d9bf7a" : "#8B0000";
+
   return (
     <div className="lg:hidden px-8 pb-2">
-      <div className="relative h-[12px] flex items-center justify-center max-w-[290px] mx-auto">
-        <div
-          className="absolute left-0 right-0 h-px"
-          style={{ backgroundColor: isDark ? "rgba(217,191,122,0.45)" : "rgba(139,0,0,0.42)" }}
-        />
-        <svg
-          viewBox="0 0 120 24"
-          className="relative w-[58px] h-[15px]"
-          aria-hidden="true"
-        >
+      <div className="h-[14px] flex items-center justify-center max-w-[290px] mx-auto">
+        <div className="h-px flex-1" style={{ backgroundColor: lineColor }} />
+        <svg viewBox="0 0 120 24" className="w-[62px] h-[16px] shrink-0 mx-[2px]" aria-hidden="true">
           <path
-            d="M2 12 H38 C42 12 42 7 45 7 C49 7 48 18 52 18 C57 18 55 4 60 4 C65 4 63 20 68 20 C72 20 72 12 78 12 H118"
+            d="M2 12 H34 C41 12 41 7 45 7 C50 7 49 18 53 18 C58 18 56 4 60 4 C64 4 62 20 67 20 C72 20 72 12 80 12 H118"
             fill="none"
-            stroke={isDark ? "#d9bf7a" : "#8B0000"}
+            stroke={waveColor}
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
         </svg>
+        <div className="h-px flex-1" style={{ backgroundColor: lineColor }} />
       </div>
     </div>
   );
@@ -77,9 +63,7 @@ export default function Header() {
       className="sticky top-0 z-50 transition-colors duration-300 overflow-hidden"
       style={{
         backgroundColor: isDark ? "#0d0d0f" : "#ffffff",
-        borderBottom: isDark
-          ? "1px solid rgba(255,255,255,0.08)"
-          : "1px solid rgba(0,0,0,0.08)",
+        borderBottom: isDark ? "1px solid rgba(255,255,255,0.08)" : "1px solid rgba(0,0,0,0.08)",
       }}
     >
       <div className="max-w-[1200px] mx-auto px-4 min-[390px]:px-5">
@@ -90,10 +74,7 @@ export default function Header() {
                 key={item.label}
                 href={item.href}
                 className="text-[12px] font-semibold tracking-[0.12em] uppercase transition-colors duration-200"
-                style={{
-                  fontFamily: "'Source Sans 3', sans-serif",
-                  color: isDark ? "#c9c6cf" : "#1a2a3a",
-                }}
+                style={{ fontFamily: "'Source Sans 3', sans-serif", color: isDark ? "#c9c6cf" : "#1a2a3a" }}
               >
                 {item.label}
               </Link>
@@ -113,10 +94,7 @@ export default function Header() {
             <MastheadLogo isDark={isDark} />
             <p
               className="lg:hidden mt-1 text-[15px] italic leading-none whitespace-nowrap"
-              style={{
-                fontFamily: "'Lora', Georgia, serif",
-                color: isDark ? "#bcb7a6" : "#333333",
-              }}
+              style={{ fontFamily: "'Lora', Georgia, serif", color: isDark ? "#bcb7a6" : "#333333" }}
             >
               Vaš prozor u svet
             </p>
@@ -128,10 +106,7 @@ export default function Header() {
                 key={item.label}
                 href={item.href}
                 className="text-[12px] font-semibold tracking-[0.12em] uppercase transition-colors duration-200"
-                style={{
-                  fontFamily: "'Source Sans 3', sans-serif",
-                  color: isDark ? "#c9c6cf" : "#1a2a3a",
-                }}
+                style={{ fontFamily: "'Source Sans 3', sans-serif", color: isDark ? "#c9c6cf" : "#1a2a3a" }}
               >
                 {item.label}
               </Link>
@@ -139,10 +114,7 @@ export default function Header() {
 
             <span
               className="text-[12px] font-medium italic ml-2"
-              style={{
-                fontFamily: "'Lora', serif",
-                color: isDark ? "#bcb7a6" : "#5a6a7a",
-              }}
+              style={{ fontFamily: "'Lora', serif", color: isDark ? "#bcb7a6" : "#5a6a7a" }}
             >
               Veritas ante omnia
             </span>
@@ -151,9 +123,7 @@ export default function Header() {
               onClick={toggleTheme}
               className="ml-3 p-1.5 rounded-full transition-colors duration-200"
               style={{
-                backgroundColor: isDark
-                  ? "rgba(255,255,255,0.08)"
-                  : "rgba(0,0,0,0.06)",
+                backgroundColor: isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)",
                 color: isDark ? "#d9bf7a" : "#1a2a3a",
               }}
               aria-label={isDark ? "Svetli režim" : "Tamni režim"}
@@ -167,9 +137,7 @@ export default function Header() {
               onClick={toggleTheme}
               className="p-2 rounded-full transition-colors duration-200"
               style={{
-                backgroundColor: isDark
-                  ? "rgba(255,255,255,0.08)"
-                  : "rgba(26,42,58,0.07)",
+                backgroundColor: isDark ? "rgba(255,255,255,0.08)" : "rgba(26,42,58,0.07)",
                 color: isDark ? "#d9bf7a" : "#1a2a3a",
               }}
               aria-label={isDark ? "Svetli režim" : "Tamni režim"}
@@ -194,9 +162,7 @@ export default function Header() {
           className="lg:hidden px-5 pb-5"
           style={{
             backgroundColor: isDark ? "#0d0d0f" : "#ffffff",
-            borderTop: isDark
-              ? "1px solid rgba(255,255,255,0.08)"
-              : "1px solid rgba(0,0,0,0.08)",
+            borderTop: isDark ? "1px solid rgba(255,255,255,0.08)" : "1px solid rgba(0,0,0,0.08)",
           }}
         >
           <nav className="flex flex-col gap-3 pt-3">
@@ -205,10 +171,7 @@ export default function Header() {
                 key={item.label}
                 href={item.href}
                 className="text-[13px] font-semibold tracking-[0.1em] uppercase py-2 transition-colors duration-200"
-                style={{
-                  fontFamily: "'Source Sans 3', sans-serif",
-                  color: isDark ? "#c9c6cf" : "#1a2a3a",
-                }}
+                style={{ fontFamily: "'Source Sans 3', sans-serif", color: isDark ? "#c9c6cf" : "#1a2a3a" }}
                 onClick={() => setMobileOpen(false)}
               >
                 {item.label}
@@ -218,10 +181,7 @@ export default function Header() {
 
           <p
             className="text-[12px] italic mt-4"
-            style={{
-              fontFamily: "'Lora', serif",
-              color: isDark ? "#bcb7a6" : "#5a6a7a",
-            }}
+            style={{ fontFamily: "'Lora', serif", color: isDark ? "#bcb7a6" : "#5a6a7a" }}
           >
             Veritas ante omnia
           </p>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,13 +1,11 @@
 /*
  * DESIGN: "Diplomatska Klasika" — Foreign Affairs-inspired header
- * Light mode: Light blue top bar (#d6e8f0) — Foreign Affairs style
- * Dark mode: Dark bar (#0d0d0f)
- * Update: Added "Naša planeta" in top menu (right side, next to Srbija)
+ * Mobile update: centered Novi Talas masthead, tagline and red wave divider.
  */
 
 import { useState } from "react";
 import { Link } from "wouter";
-import { Menu, X, Sun, Moon } from "lucide-react";
+import { Menu, X, Sun, Moon, Search } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const navItems = [
@@ -16,6 +14,58 @@ const navItems = [
   { label: "Srbija", href: "/srbija" },
   { label: "Naša planeta", href: "/nasa-planeta" },
 ];
+
+function MastheadLogo({ isDark }: { isDark: boolean }) {
+  return (
+    <Link href="/" className="flex items-center justify-center gap-0 no-underline">
+      <span
+        className="font-extrabold tracking-[0.22em] uppercase text-[25px] md:text-[22px]"
+        style={{
+          fontFamily: "'Lora', serif",
+          color: isDark ? "#f6f3e8" : "#1a2a3a",
+        }}
+      >
+        NOVI{" "}
+      </span>
+      <span
+        className="font-extrabold tracking-[0.22em] uppercase text-[25px] md:text-[22px]"
+        style={{
+          fontFamily: "'Lora', serif",
+          color: isDark ? "#d9bf7a" : "#8B0000",
+        }}
+      >
+        TALAS
+      </span>
+    </Link>
+  );
+}
+
+function MobileWaveDivider({ isDark }: { isDark: boolean }) {
+  return (
+    <div className="lg:hidden px-9 pb-3">
+      <div className="relative h-[16px] flex items-center justify-center">
+        <div
+          className="absolute left-0 right-0 h-px"
+          style={{ backgroundColor: isDark ? "rgba(217,191,122,0.45)" : "rgba(139,0,0,0.42)" }}
+        />
+        <svg
+          viewBox="0 0 120 24"
+          className="relative w-[74px] h-[18px]"
+          aria-hidden="true"
+        >
+          <path
+            d="M2 12 H38 C42 12 42 7 45 7 C49 7 48 18 52 18 C57 18 55 4 60 4 C65 4 63 20 68 20 C72 20 72 12 78 12 H118"
+            fill="none"
+            stroke={isDark ? "#d9bf7a" : "#8B0000"}
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+    </div>
+  );
+}
 
 export default function Header() {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -26,14 +76,14 @@ export default function Header() {
     <header
       className="sticky top-0 z-50 transition-colors duration-300"
       style={{
-        backgroundColor: isDark ? "#0d0d0f" : "#d6e8f0",
+        backgroundColor: isDark ? "#0d0d0f" : "#ffffff",
         borderBottom: isDark
           ? "1px solid rgba(255,255,255,0.08)"
           : "1px solid rgba(0,0,0,0.08)",
       }}
     >
       <div className="max-w-[1200px] mx-auto px-5">
-        <div className="flex items-center justify-between h-[60px]">
+        <div className="relative flex items-center justify-center lg:justify-between h-[74px] lg:h-[60px]">
           {/* Left nav — desktop */}
           <nav className="hidden lg:flex items-center gap-6">
             {navItems.slice(0, 2).map((item) => (
@@ -51,27 +101,29 @@ export default function Header() {
             ))}
           </nav>
 
-          {/* Center logo */}
-          <Link href="/" className="flex items-center gap-0 no-underline">
-            <span
-              className="text-[22px] font-extrabold tracking-[0.18em] uppercase"
+          {/* Mobile left menu */}
+          <button
+            onClick={() => setMobileOpen(!mobileOpen)}
+            aria-label="Meni"
+            className="absolute left-0 lg:hidden p-1"
+            style={{ color: isDark ? "#c9c6cf" : "#1a2a3a" }}
+          >
+            {mobileOpen ? <X size={27} /> : <Menu size={27} />}
+          </button>
+
+          {/* Center logo + mobile tagline */}
+          <div className="flex flex-col items-center justify-center">
+            <MastheadLogo isDark={isDark} />
+            <p
+              className="lg:hidden mt-1 text-[16px] italic leading-none"
               style={{
-                fontFamily: "'Lora', serif",
-                color: isDark ? "#f6f3e8" : "#1a2a3a",
+                fontFamily: "'Lora', Georgia, serif",
+                color: isDark ? "#bcb7a6" : "#333333",
               }}
             >
-              NOVI{" "}
-            </span>
-            <span
-              className="text-[22px] font-extrabold tracking-[0.18em] uppercase"
-              style={{
-                fontFamily: "'Lora', serif",
-                color: isDark ? "#d9bf7a" : "#8B0000",
-              }}
-            >
-              TALAS
-            </span>
-          </Link>
+              Vaš prozor u svet
+            </p>
+          </div>
 
           {/* Right nav — desktop */}
           <div className="hidden lg:flex items-center gap-6">
@@ -99,7 +151,6 @@ export default function Header() {
               Veritas ante omnia
             </span>
 
-            {/* Theme toggle */}
             <button
               onClick={toggleTheme}
               className="ml-3 p-1.5 rounded-full transition-colors duration-200"
@@ -115,39 +166,40 @@ export default function Header() {
             </button>
           </div>
 
-          {/* Mobile: theme toggle + menu button */}
-          <div className="lg:hidden flex items-center gap-3">
+          {/* Mobile right actions */}
+          <div className="absolute right-0 lg:hidden flex items-center gap-3">
             <button
               onClick={toggleTheme}
-              className="p-1.5 rounded-full transition-colors duration-200"
+              className="p-2 rounded-full transition-colors duration-200"
               style={{
                 backgroundColor: isDark
                   ? "rgba(255,255,255,0.08)"
-                  : "rgba(0,0,0,0.06)",
+                  : "rgba(26,42,58,0.07)",
                 color: isDark ? "#d9bf7a" : "#1a2a3a",
               }}
               aria-label={isDark ? "Svetli režim" : "Tamni režim"}
             >
-              {isDark ? <Sun size={16} /> : <Moon size={16} />}
+              {isDark ? <Sun size={20} /> : <Moon size={20} />}
             </button>
-
             <button
-              onClick={() => setMobileOpen(!mobileOpen)}
-              aria-label="Meni"
+              className="p-1"
               style={{ color: isDark ? "#c9c6cf" : "#1a2a3a" }}
+              aria-label="Pretraga"
             >
-              {mobileOpen ? <X size={24} /> : <Menu size={24} />}
+              <Search size={25} />
             </button>
           </div>
         </div>
       </div>
+
+      <MobileWaveDivider isDark={isDark} />
 
       {/* Mobile nav */}
       {mobileOpen && (
         <div
           className="lg:hidden px-5 pb-5"
           style={{
-            backgroundColor: isDark ? "#0d0d0f" : "#d6e8f0",
+            backgroundColor: isDark ? "#0d0d0f" : "#ffffff",
             borderTop: isDark
               ? "1px solid rgba(255,255,255,0.08)"
               : "1px solid rgba(0,0,0,0.08)",

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,6 +1,6 @@
 /*
  * DESIGN: "Diplomatska Klasika" — Foreign Affairs-inspired header
- * Mobile update: centered Novi Talas masthead, tagline and red wave divider.
+ * Mobile update: centered Novi Talas masthead, one-line tagline and red wave divider.
  */
 
 import { useState } from "react";
@@ -17,9 +17,9 @@ const navItems = [
 
 function MastheadLogo({ isDark }: { isDark: boolean }) {
   return (
-    <Link href="/" className="flex items-center justify-center gap-0 no-underline">
+    <Link href="/" className="flex items-center justify-center gap-0 no-underline whitespace-nowrap">
       <span
-        className="font-extrabold tracking-[0.22em] uppercase text-[25px] md:text-[22px]"
+        className="font-extrabold tracking-[0.19em] uppercase text-[24px] min-[390px]:text-[25px] md:text-[22px]"
         style={{
           fontFamily: "'Lora', serif",
           color: isDark ? "#f6f3e8" : "#1a2a3a",
@@ -28,7 +28,7 @@ function MastheadLogo({ isDark }: { isDark: boolean }) {
         NOVI{" "}
       </span>
       <span
-        className="font-extrabold tracking-[0.22em] uppercase text-[25px] md:text-[22px]"
+        className="font-extrabold tracking-[0.19em] uppercase text-[24px] min-[390px]:text-[25px] md:text-[22px]"
         style={{
           fontFamily: "'Lora', serif",
           color: isDark ? "#d9bf7a" : "#8B0000",
@@ -42,15 +42,15 @@ function MastheadLogo({ isDark }: { isDark: boolean }) {
 
 function MobileWaveDivider({ isDark }: { isDark: boolean }) {
   return (
-    <div className="lg:hidden px-9 pb-3">
-      <div className="relative h-[16px] flex items-center justify-center">
+    <div className="lg:hidden px-9 pb-2">
+      <div className="relative h-[12px] flex items-center justify-center">
         <div
           className="absolute left-0 right-0 h-px"
           style={{ backgroundColor: isDark ? "rgba(217,191,122,0.45)" : "rgba(139,0,0,0.42)" }}
         />
         <svg
           viewBox="0 0 120 24"
-          className="relative w-[74px] h-[18px]"
+          className="relative w-[66px] h-[16px]"
           aria-hidden="true"
         >
           <path
@@ -82,9 +82,8 @@ export default function Header() {
           : "1px solid rgba(0,0,0,0.08)",
       }}
     >
-      <div className="max-w-[1200px] mx-auto px-5">
-        <div className="relative flex items-center justify-center lg:justify-between h-[74px] lg:h-[60px]">
-          {/* Left nav — desktop */}
+      <div className="max-w-[1200px] mx-auto px-4 min-[390px]:px-5">
+        <div className="relative flex items-center justify-center lg:justify-between h-[66px] lg:h-[60px]">
           <nav className="hidden lg:flex items-center gap-6">
             {navItems.slice(0, 2).map((item) => (
               <Link
@@ -101,21 +100,19 @@ export default function Header() {
             ))}
           </nav>
 
-          {/* Mobile left menu */}
           <button
             onClick={() => setMobileOpen(!mobileOpen)}
             aria-label="Meni"
             className="absolute left-0 lg:hidden p-1"
             style={{ color: isDark ? "#c9c6cf" : "#1a2a3a" }}
           >
-            {mobileOpen ? <X size={27} /> : <Menu size={27} />}
+            {mobileOpen ? <X size={26} /> : <Menu size={26} />}
           </button>
 
-          {/* Center logo + mobile tagline */}
-          <div className="flex flex-col items-center justify-center">
+          <div className="flex flex-col items-center justify-center max-w-[230px] min-[390px]:max-w-none">
             <MastheadLogo isDark={isDark} />
             <p
-              className="lg:hidden mt-1 text-[16px] italic leading-none"
+              className="lg:hidden mt-1 text-[15px] italic leading-none whitespace-nowrap"
               style={{
                 fontFamily: "'Lora', Georgia, serif",
                 color: isDark ? "#bcb7a6" : "#333333",
@@ -125,7 +122,6 @@ export default function Header() {
             </p>
           </div>
 
-          {/* Right nav — desktop */}
           <div className="hidden lg:flex items-center gap-6">
             {navItems.slice(2).map((item) => (
               <Link
@@ -166,8 +162,7 @@ export default function Header() {
             </button>
           </div>
 
-          {/* Mobile right actions */}
-          <div className="absolute right-0 lg:hidden flex items-center gap-3">
+          <div className="absolute right-0 lg:hidden flex items-center gap-2 min-[390px]:gap-3">
             <button
               onClick={toggleTheme}
               className="p-2 rounded-full transition-colors duration-200"
@@ -179,14 +174,14 @@ export default function Header() {
               }}
               aria-label={isDark ? "Svetli režim" : "Tamni režim"}
             >
-              {isDark ? <Sun size={20} /> : <Moon size={20} />}
+              {isDark ? <Sun size={19} /> : <Moon size={19} />}
             </button>
             <button
               className="p-1"
               style={{ color: isDark ? "#c9c6cf" : "#1a2a3a" }}
               aria-label="Pretraga"
             >
-              <Search size={25} />
+              <Search size={24} />
             </button>
           </div>
         </div>
@@ -194,7 +189,6 @@ export default function Header() {
 
       <MobileWaveDivider isDark={isDark} />
 
-      {/* Mobile nav */}
       {mobileOpen && (
         <div
           className="lg:hidden px-5 pb-5"

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -153,12 +153,10 @@ function SmallArticleCard({
           </Link>
         </h3>
         <p
-          className="mt-2 text-[15px] md:text-[14px] leading-[1.42]"
+          className="hidden md:block mt-2 text-[14px] leading-[1.42]"
           style={{
             fontFamily: "'Lora', Georgia, serif",
             color: isDark ? "#9a978f" : "#555",
-            maxHeight: "4.28em",
-            overflow: "hidden",
           }}
         >
           {description}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,9 +1,6 @@
 /*
  * DESIGN: "Diplomatska Klasika" v3  -  Foreign Affairs-inspired homepage
- * Structure (final):
- * 1. HERO — Artemis II splashdown (full-width, large)
- * 2. SMALL NEWS GRID (4 cards)
- * 3. LIVE BLOCK (compact, max 3 entries)
+ * Mobile update: editorial masthead, image-first hero and cleaner magazine cards.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -35,7 +32,6 @@ const PREVIOUS_HERO_ARTICLE = {
   imageCredit: "Reuters / AP",
 };
 
-// Simple fade-in on scroll hook
 function useFadeIn() {
   const ref = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(false);
@@ -92,6 +88,7 @@ interface SmallArticleCardProps {
   description: string;
   imageSrc: string;
   imageAlt: string;
+  variant?: "split" | "tile";
 }
 
 function SmallArticleCard({
@@ -101,16 +98,53 @@ function SmallArticleCard({
   description,
   imageSrc,
   imageAlt,
+  variant = "split",
 }: SmallArticleCardProps) {
   const { theme } = useTheme();
   const isDark = theme === "dark";
 
+  if (variant === "tile") {
+    return (
+      <article
+        className="overflow-hidden rounded-xl border"
+        style={{
+          borderColor: isDark ? "#2a2a2e" : "#eee",
+          backgroundColor: isDark ? "#17191f" : "#ffffff",
+        }}
+      >
+        <Link href={href} className="block no-underline">
+          <img
+            src={imageSrc}
+            alt={imageAlt}
+            className="w-full h-[120px] object-cover block"
+            loading="lazy"
+            decoding="async"
+          />
+          <div className="p-3">
+            <span className="kicker">{category}</span>
+            <h3
+              className="mt-1 text-[17px] font-bold leading-[1.2]"
+              style={{
+                fontFamily: "'Lora', Georgia, serif",
+                color: isDark ? "#e0ddd5" : "#111",
+              }}
+            >
+              {title}
+            </h3>
+          </div>
+        </Link>
+      </article>
+    );
+  }
+
   return (
-    <div className="grid grid-cols-[1fr_100px] gap-4 items-start">
+    <article
+      className="grid grid-cols-[1fr_118px] md:grid-cols-[1fr_100px] gap-4 items-start rounded-xl md:rounded-none p-0 md:p-0"
+    >
       <div>
         <span className="kicker">{category}</span>
         <h3
-          className="mt-1 text-[18px] md:text-[20px] font-bold leading-[1.25]"
+          className="mt-1 text-[20px] md:text-[20px] font-bold leading-[1.2]"
           style={{
             fontFamily: "'Lora', Georgia, serif",
             color: isDark ? "#e0ddd5" : "#111",
@@ -121,28 +155,30 @@ function SmallArticleCard({
           </Link>
         </h3>
         <p
-          className="mt-1 text-[14px] leading-[1.5]"
+          className="mt-2 text-[15px] md:text-[14px] leading-[1.45]"
           style={{
             fontFamily: "'Lora', Georgia, serif",
-            color: isDark ? "#7a7872" : "#666",
+            color: isDark ? "#9a978f" : "#555",
           }}
         >
           {description}
         </p>
       </div>
 
-      <img
-        src={imageSrc}
-        alt={imageAlt}
-        className="w-[100px] h-[75px] object-cover border"
-        style={{
-          borderColor: isDark ? "#2a2a2e" : "#eee",
-          backgroundColor: isDark ? "#1a1c22" : "#f5f5f5",
-        }}
-        loading="lazy"
-        decoding="async"
-      />
-    </div>
+      <Link href={href} className="block no-underline">
+        <img
+          src={imageSrc}
+          alt={imageAlt}
+          className="w-[118px] h-[92px] md:w-[100px] md:h-[75px] object-cover border rounded-md md:rounded-none"
+          style={{
+            borderColor: isDark ? "#2a2a2e" : "#eee",
+            backgroundColor: isDark ? "#1a1c22" : "#f5f5f5",
+          }}
+          loading="lazy"
+          decoding="async"
+        />
+      </Link>
+    </article>
   );
 }
 
@@ -157,9 +193,9 @@ export default function Home() {
     >
       <Header />
 
-      {/* Hero banner */}
+      {/* Desktop hero brand banner — hidden on mobile because mobile header carries the identity */}
       <section
-        className="relative w-full overflow-hidden h-[22vh] md:h-[28vh] hero-section"
+        className="hidden md:block relative w-full overflow-hidden h-[28vh] hero-section"
         style={{
           backgroundImage: `url(/hero/naslovna-novitalas.jpg), linear-gradient(to bottom, var(--nt-hero-bg), var(--nt-hero-bg-end))`,
           backgroundColor: "var(--nt-hero-bg)",
@@ -173,16 +209,15 @@ export default function Home() {
           />
         )}
 
-        {/* SEO: visually hidden H1 */}
         <h1 className="sr-only">Novi Talas</h1>
         <p className="sr-only">
           Novi Talas je digitalni nedeljnik koji donosi analize geopolitike,
           Srbije i sveta, uz fokus na najvažnije događaje dana.
         </p>
 
-        <div className="absolute inset-x-0 bottom-0 pb-4 md:pb-6 flex justify-center">
+        <div className="absolute inset-x-0 bottom-0 pb-6 flex justify-center">
           <p
-            className="hero-tagline text-[18px] md:text-[26px] italic tracking-wide"
+            className="hero-tagline text-[26px] italic tracking-wide"
             style={{
               fontFamily: "'Playfair Display', Georgia, serif",
               color: isDark ? "#e0ddd5" : "#1a1a1a",
@@ -196,21 +231,39 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Main */}
       <main
-        className="pt-9 pb-12 md:pt-12 md:pb-16 flex-1"
+        className="pt-0 pb-12 md:pt-12 md:pb-16 flex-1"
         style={{ backgroundColor: isDark ? "#111318" : "#ffffff" }}
       >
-        <div className="max-w-[1200px] mx-auto px-5">
-          {/* ======================
-              1. HERO
-             ====================== */}
+        <div className="max-w-[1200px] mx-auto px-5 md:px-5">
+          {/* 1. HERO */}
           <FadeIn className="mb-10">
-            <article>
+            <article className="flex flex-col">
+              <Link
+                href={HERO_ARTICLE.href}
+                className="block no-underline -mx-5 md:mx-0 order-first md:order-none mb-5 md:mb-0"
+              >
+                <div
+                  className="relative w-full overflow-hidden md:rounded-xl aspect-[16/9]"
+                  style={{
+                    border: isDark ? "1px solid #2a2a2e" : "1px solid #e5e5e5",
+                  }}
+                >
+                  <img
+                    src={HERO_ARTICLE.imageSrc}
+                    alt={HERO_ARTICLE.imageAlt}
+                    className="w-full h-full object-cover block"
+                    fetchPriority="high"
+                    decoding="async"
+                  />
+                </div>
+                <p className="photo-credit px-5 md:px-0">{HERO_ARTICLE.imageCredit}</p>
+              </Link>
+
               <span className="kicker block mb-2">{HERO_ARTICLE.category}</span>
 
               <h2
-                className="mt-2 mb-3 text-[32px] md:text-[46px] font-bold leading-[1.1]"
+                className="mt-2 mb-3 text-[33px] md:text-[46px] font-bold leading-[1.08]"
                 style={{
                   fontFamily: "'Playfair Display', Georgia, serif",
                   fontWeight: 700,
@@ -227,7 +280,7 @@ export default function Home() {
               </h2>
 
               <p
-                className="text-[18px] md:text-[20px] leading-[1.6] mb-5"
+                className="text-[18px] md:text-[20px] leading-[1.55] md:leading-[1.6] mb-2 md:mb-5"
                 style={{
                   fontFamily: "'Lora', Georgia, serif",
                   color: isDark ? "#9a978f" : "#555",
@@ -235,35 +288,15 @@ export default function Home() {
               >
                 {HERO_ARTICLE.description}
               </p>
-
-              <Link href={HERO_ARTICLE.href} className="block no-underline">
-                <div
-                  className="relative w-full overflow-hidden rounded-xl aspect-video"
-                  style={{
-                    border: isDark ? "1px solid #2a2a2e" : "1px solid #e5e5e5",
-                  }}
-                >
-                  <img
-                    src={HERO_ARTICLE.imageSrc}
-                    alt={HERO_ARTICLE.imageAlt}
-                    className="w-full h-full object-cover block"
-                    fetchPriority="high"
-                    decoding="async"
-                  />
-                </div>
-                <p className="photo-credit">{HERO_ARTICLE.imageCredit}</p>
-              </Link>
             </article>
           </FadeIn>
 
           <hr
-            className="editorial-divider mb-10"
+            className="editorial-divider mb-8 md:mb-10"
             style={{ borderColor: isDark ? "#2a2a2e" : "#e5e5e5" }}
           />
 
-          {/* ======================
-              2. SMALL NEWS GRID (4 cards)
-             ====================== */}
+          {/* 2. SMALL NEWS GRID */}
           <FadeIn className="mb-10">
             <div className="flex flex-col gap-6">
               <SmallArticleCard
@@ -299,25 +332,27 @@ export default function Home() {
 
               <hr className="editorial-divider" />
 
-              <SmallArticleCard
-                category="Geopolitika"
-                href="/geopolitika/tramp-pokrenuo-udare-na-iran-nakon-obaranja-americkog-helikoptera"
-                title="KRIZA SAD–IRAN"
-                description="SAD izvele novu seriju udara na ciljeve u Iranu dok Teheran najavljuje odgovor. Sukob koji je počeo obaranjem američkog helikoptera ulazi u novu fazu, a pažnja sveta ostaje usmerena ka Ormuskom moreuzu i bezbednosti Persijskog zaliva."
-                imageSrc="/news/usa-iran-red-line.jpg"
-                imageAlt="Kriza SAD–Iran i vojni udari na ciljeve u Iranu"
-              />
+              <div className="grid grid-cols-1 min-[420px]:grid-cols-2 md:grid-cols-1 gap-4 md:gap-6">
+                <SmallArticleCard
+                  variant="tile"
+                  category="Geopolitika"
+                  href="/geopolitika/tramp-pokrenuo-udare-na-iran-nakon-obaranja-americkog-helikoptera"
+                  title="KRIZA SAD–IRAN"
+                  description="SAD izvele novu seriju udara na ciljeve u Iranu dok Teheran najavljuje odgovor."
+                  imageSrc="/news/usa-iran-red-line.jpg"
+                  imageAlt="Kriza SAD–Iran i vojni udari na ciljeve u Iranu"
+                />
 
-              <hr className="editorial-divider" />
-
-              <SmallArticleCard
-                category="Naša planeta"
-                href="/nasa-planeta/nasa-predstavila-posadu-artemis-iii"
-                title="NASA predstavila posadu misije Artemis III"
-                description="Povratak ljudi na Mesec ulazi u novu fazu — NASA je zvanično objavila posadu prve misije koja bi trebalo da vrati astronaute na površinu Meseca posle više od pola veka."
-                imageSrc="/news/artemis-nasa-3.jpg"
-                imageAlt="NASA Artemis III — posada misije koja treba da vrati ljude na Mesec"
-              />
+                <SmallArticleCard
+                  variant="tile"
+                  category="Naša planeta"
+                  href="/nasa-planeta/nasa-predstavila-posadu-artemis-iii"
+                  title="NASA predstavila posadu misije Artemis III"
+                  description="Povratak ljudi na Mesec ulazi u novu fazu."
+                  imageSrc="/news/artemis-nasa-3.jpg"
+                  imageAlt="NASA Artemis III — posada misije koja treba da vrati ljude na Mesec"
+                />
+              </div>
             </div>
           </FadeIn>
         </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -14,7 +14,7 @@ const HERO_ARTICLE = {
   category: "Geopolitika",
   title: "Mundijal na granici: fudbal, vize i politika moći",
   description:
-    "Dok FIFA slavi najveći fudbalski spektakl na svetu, američka vizna politika, ratne tenzije i pitanje ko uopšte ima pravo da učestvuje na Svetskom prvenstvu već su postali deo turnira.",
+    "Dok FIFA slavi najveći fudbalski spektakl na svetu, američka vizna politika, ratne tenzije i pitanje ko uopšte ima pravo da učestvuje na Svetskom prvenstvu već su deo turnira.",
   imageSrc: "/news/world-cup-visas.jpg",
   imageAlt: "Mundijal, vize i geopolitika na granici",
   imageCredit: "",
@@ -233,7 +233,7 @@ export default function Home() {
         style={{ backgroundColor: isDark ? "#111318" : "#ffffff" }}
       >
         <div className="max-w-[1200px] mx-auto px-5 md:px-5">
-          <FadeIn className="mb-9 md:mb-10">
+          <FadeIn className="mb-11 md:mb-10">
             <article className="flex flex-col">
               <Link
                 href={HERO_ARTICLE.href}
@@ -278,7 +278,7 @@ export default function Home() {
               </h2>
 
               <p
-                className="text-[18px] md:text-[20px] leading-[1.5] md:leading-[1.6] mb-1 md:mb-5"
+                className="text-[17px] min-[390px]:text-[18px] md:text-[20px] leading-[1.48] md:leading-[1.6] mb-2 md:mb-5"
                 style={{
                   fontFamily: "'Lora', Georgia, serif",
                   color: isDark ? "#9a978f" : "#555",
@@ -290,7 +290,7 @@ export default function Home() {
           </FadeIn>
 
           <hr
-            className="editorial-divider mb-7 md:mb-10"
+            className="editorial-divider mb-8 md:mb-10"
             style={{ borderColor: isDark ? "#2a2a2e" : "#e5e5e5" }}
           />
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -17,7 +17,7 @@ const HERO_ARTICLE = {
     "Dok FIFA slavi najveći fudbalski spektakl na svetu, američka vizna politika, ratne tenzije i pitanje ko uopšte ima pravo da učestvuje na Svetskom prvenstvu već su postali deo turnira.",
   imageSrc: "/news/world-cup-visas.jpg",
   imageAlt: "Mundijal, vize i geopolitika na granici",
-  imageCredit: "Reuters",
+  imageCredit: "",
 };
 
 const PREVIOUS_HERO_ARTICLE = {
@@ -253,7 +253,9 @@ export default function Home() {
                     decoding="async"
                   />
                 </div>
-                <p className="photo-credit px-5 md:px-0">{HERO_ARTICLE.imageCredit}</p>
+                {HERO_ARTICLE.imageCredit ? (
+                  <p className="photo-credit px-5 md:px-0">{HERO_ARTICLE.imageCredit}</p>
+                ) : null}
               </Link>
 
               <span className="kicker block mb-2">{HERO_ARTICLE.category}</span>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -138,13 +138,11 @@ function SmallArticleCard({
   }
 
   return (
-    <article
-      className="grid grid-cols-[1fr_118px] md:grid-cols-[1fr_100px] gap-4 items-start rounded-xl md:rounded-none p-0 md:p-0"
-    >
+    <article className="grid grid-cols-[1fr_112px] min-[390px]:grid-cols-[1fr_118px] md:grid-cols-[1fr_100px] gap-4 items-start">
       <div>
         <span className="kicker">{category}</span>
         <h3
-          className="mt-1 text-[20px] md:text-[20px] font-bold leading-[1.2]"
+          className="mt-1 text-[19px] min-[390px]:text-[20px] md:text-[20px] font-bold leading-[1.18]"
           style={{
             fontFamily: "'Lora', Georgia, serif",
             color: isDark ? "#e0ddd5" : "#111",
@@ -155,10 +153,12 @@ function SmallArticleCard({
           </Link>
         </h3>
         <p
-          className="mt-2 text-[15px] md:text-[14px] leading-[1.45]"
+          className="mt-2 text-[15px] md:text-[14px] leading-[1.42]"
           style={{
             fontFamily: "'Lora', Georgia, serif",
             color: isDark ? "#9a978f" : "#555",
+            maxHeight: "4.28em",
+            overflow: "hidden",
           }}
         >
           {description}
@@ -169,7 +169,7 @@ function SmallArticleCard({
         <img
           src={imageSrc}
           alt={imageAlt}
-          className="w-[118px] h-[92px] md:w-[100px] md:h-[75px] object-cover border rounded-md md:rounded-none"
+          className="w-[112px] h-[84px] min-[390px]:w-[118px] min-[390px]:h-[88px] md:w-[100px] md:h-[75px] object-cover border rounded-md md:rounded-none"
           style={{
             borderColor: isDark ? "#2a2a2e" : "#eee",
             backgroundColor: isDark ? "#1a1c22" : "#f5f5f5",
@@ -193,7 +193,6 @@ export default function Home() {
     >
       <Header />
 
-      {/* Desktop hero brand banner — hidden on mobile because mobile header carries the identity */}
       <section
         className="hidden md:block relative w-full overflow-hidden h-[28vh] hero-section"
         style={{
@@ -236,8 +235,7 @@ export default function Home() {
         style={{ backgroundColor: isDark ? "#111318" : "#ffffff" }}
       >
         <div className="max-w-[1200px] mx-auto px-5 md:px-5">
-          {/* 1. HERO */}
-          <FadeIn className="mb-10">
+          <FadeIn className="mb-9 md:mb-10">
             <article className="flex flex-col">
               <Link
                 href={HERO_ARTICLE.href}
@@ -263,7 +261,7 @@ export default function Home() {
               <span className="kicker block mb-2">{HERO_ARTICLE.category}</span>
 
               <h2
-                className="mt-2 mb-3 text-[33px] md:text-[46px] font-bold leading-[1.08]"
+                className="mt-2 mb-3 text-[32px] min-[390px]:text-[34px] md:text-[46px] font-bold leading-[1.08]"
                 style={{
                   fontFamily: "'Playfair Display', Georgia, serif",
                   fontWeight: 700,
@@ -280,7 +278,7 @@ export default function Home() {
               </h2>
 
               <p
-                className="text-[18px] md:text-[20px] leading-[1.55] md:leading-[1.6] mb-2 md:mb-5"
+                className="text-[18px] md:text-[20px] leading-[1.5] md:leading-[1.6] mb-1 md:mb-5"
                 style={{
                   fontFamily: "'Lora', Georgia, serif",
                   color: isDark ? "#9a978f" : "#555",
@@ -292,18 +290,17 @@ export default function Home() {
           </FadeIn>
 
           <hr
-            className="editorial-divider mb-8 md:mb-10"
+            className="editorial-divider mb-7 md:mb-10"
             style={{ borderColor: isDark ? "#2a2a2e" : "#e5e5e5" }}
           />
 
-          {/* 2. SMALL NEWS GRID */}
           <FadeIn className="mb-10">
-            <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-5 md:gap-6">
               <SmallArticleCard
                 category="Naša planeta"
                 href="/nasa-planeta/zasto-ljudi-kada-lutaju-cesto-skrecu-ulevo"
                 title="Zašto ljudi, kada lutaju, često skreću ulevo?"
-                description="Kada ljudi izgube spoljne orijentire i pokušaju da hodaju nasumično, njihovo kretanje često se ne razvija kao prava linija, već kao blagi luk — neretko ulevo."
+                description="Kada ljudi izgube spoljne orijentire, njihovo kretanje često ne ide pravom linijom, već blagim lukom — neretko ulevo."
                 imageSrc="/news/human-walking-left.jpg"
                 imageAlt="Ljudi koji hodaju kroz otvoren prostor, sa putanjama koje se blago uvijaju ulevo"
               />
@@ -314,7 +311,7 @@ export default function Home() {
                 category="Geopolitika"
                 href="/geopolitika/eu-migration-rules-2026"
                 title="Nova migraciona pravila Evropske unije ulaze u primenu"
-                description="Novi evropski pakt menja pravila za azil, granice i deportacije, uz zajedničke procedure i novi sistem solidarnosti među državama članicama."
+                description="Novi evropski pakt menja pravila za azil, granice i deportacije, uz zajedničke procedure i sistem solidarnosti."
                 imageSrc="/news/eu-flags.jpg"
                 imageAlt="Zastave Evropske unije"
               />
@@ -325,7 +322,7 @@ export default function Home() {
                 category={PREVIOUS_HERO_ARTICLE.category}
                 href={PREVIOUS_HERO_ARTICLE.href}
                 title={PREVIOUS_HERO_ARTICLE.title}
-                description={PREVIOUS_HERO_ARTICLE.description}
+                description="Pakistan tvrdi da su SAD i Iran usaglasili tekst mirovnog sporazuma, dok Teheran poručuje da konačna odluka još nije doneta."
                 imageSrc={PREVIOUS_HERO_ARTICLE.imageSrc}
                 imageAlt={PREVIOUS_HERO_ARTICLE.imageAlt}
               />

--- a/client/src/pages/mundijal-na-granici-fudbal-vize-i-politika-moci.tsx
+++ b/client/src/pages/mundijal-na-granici-fudbal-vize-i-politika-moci.tsx
@@ -44,7 +44,6 @@ export default function MundijalNaGraniciFudbalVizeIPolitikaMoci() {
       deck="Dok FIFA slavi najveći fudbalski spektakl na svetu, američka vizna politika, ratne tenzije i pitanje ko uopšte ima pravo da učestvuje na Svetskom prvenstvu već su postali deo turnira."
       imageSrc={IMAGE_SRC}
       imageAlt="Fudbalski stadion i kontrola granice kao simbol geopolitike Mundijala"
-      imageCredit="Reuters"
       paragraphs={PARAGRAPHS}
       infoBox={INFO_BOX}
       backHref="/geopolitika"


### PR DESCRIPTION
Mobilni redizajn u posebnom branch-u.

Urađeno:
- novi mobilni header sa centriranim NOVI TALAS logotipom
- dodat slogan „Vaš prozor u svet” u mobilni header
- dodata tanka crvena linija sa talasom ispod headera
- mobilna naslovna sada otvara sadržaj slikom glavne vesti, bez dodatnog brending banera
- hero vest na mobilnom dobija magazinski image-first raspored
- kartice na mobilnom su doterane u urednički/magazinski ritam
- nema „min čitanja” i nema bookmark elemenata

Nisam dirao desktop strukturu namerno, osim minimalnih responsive klasa. ArticleTemplate nisam menjao u ovom PR-u da ne rizikujemo globalno pomeranje svih otvorenih vesti pre pregleda naslovne.