### PR TITLE
Promote Ormuz peace deal article to homepage hero

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,25 +10,25 @@ import Footer from "@/components/Footer";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const HERO_ARTICLE = {
-  href: "/nasa-planeta/sta-kratki-video-snimci-rade-decjem-mozgu",
-  category: "Naša planeta",
-  title: "Šta kratki video-snimci rade dečjem mozgu? Britanci pokrenuli laboratoriju da to konačno izmere",
+  href: "/geopolitika/sad-i-iran-blizu-sporazuma-pakistan-tvrdi-da-je-tekst-dogovoren-teheran-jos-oprezan",
+  category: "Geopolitika",
+  title:
+    "SAD i Iran postigli okvirni mirovni dogovor: Ormuski moreuz ponovo se otvara za svetsku trgovinu",
   description:
-    "Britanski Nerve Lab koristi AI, nosivo skeniranje mozga i analizu medijskog sadržaja kako bi ispitao kako tempo, boje, zvuk i kratki video-formati utiču na dečju pažnju, razumevanje i emocionalni odgovor.",
-  imageSrc: "/news/nerve-lab-deca-ekrani-mozak.jpg",
-  imageAlt: "Dete osvetljeno ekranom telefona, sa apstraktnim prikazom mozga i digitalnih signala",
+    "Donald Tramp je objavio da je dogovor sa Teheranom završen i naredio ukidanje američke pomorske blokade, ali ključna pitanja ostaju otvorena.",
+  imageSrc: "/news/ormuski-moreuz-nasa.jpg",
+  imageAlt: "Satelitski prikaz Ormuskog moreuza između Irana, Omana i Ujedinjenih Arapskih Emirata",
 };
 
 const ARTICLES = [
   {
-    href: "/geopolitika/sad-i-iran-blizu-sporazuma-pakistan-tvrdi-da-je-tekst-dogovoren-teheran-jos-oprezan",
-    category: "Geopolitika",
-    title:
-      "SAD i Iran postigli okvirni mirovni dogovor: Ormuski moreuz ponovo se otvara za svetsku trgovinu",
+    href: "/nasa-planeta/sta-kratki-video-snimci-rade-decjem-mozgu",
+    category: "Naša planeta",
+    title: "Šta kratki video-snimci rade dečjem mozgu? Britanci pokrenuli laboratoriju da to konačno izmere",
     description:
-      "Donald Tramp je objavio da je dogovor sa Teheranom završen i naredio ukidanje američke pomorske blokade, ali ključna pitanja ostaju otvorena.",
-    imageSrc: "/news/ormuski-moreuz-nasa.jpg",
-    imageAlt: "Satelitski prikaz Ormuskog moreuza između Irana, Omana i Ujedinjenih Arapskih Emirata",
+      "Britanski Nerve Lab koristi AI, nosivo skeniranje mozga i analizu medijskog sadržaja kako bi ispitao kako tempo, boje, zvuk i kratki video-formati utiču na dečju pažnju, razumevanje i emocionalni odgovor.",
+    imageSrc: "/news/nerve-lab-deca-ekrani-mozak.jpg",
+    imageAlt: "Dete osvetljeno ekranom telefona, sa apstraktnim prikazom mozga i digitalnih signala",
   },
   {
     href: "/geopolitika/mundijal-na-granici-fudbal-vize-i-politika-moci",


### PR DESCRIPTION
Promotes the updated SAD–Iran / Ormuski moreuz article to the homepage hero position.

Changes:
- Home hero now points to the Ormuz peace deal article.
- Nerve Lab article moved down into the first secondary slot.
- No Header/search/mobile header changes.
- No layout redesign.

Note: The article already exists in Geopolitika via the existing route and section integration.