### PR TITLE
Rescue section index article lists

### DIFF
--- a/client/src/pages/GeopolitikaIndex.tsx
+++ b/client/src/pages/GeopolitikaIndex.tsx
@@ -29,11 +29,13 @@ const ARTICLES: Article[] = [
   },
   {
     href: "/geopolitika/putin-govori-o-kraju-rata-ukrajina",
-    title: "Tramp poručio Putinu da je spreman da pomogne u okončanju rata u Ukrajini",
+    title:
+      "Tramp poručio Putinu da je spreman da pomogne u okončanju rata u Ukrajini",
     description:
       "Posle najava o smirivanju krize sa Iranom, američki predsednik pokušava da otvori i ukrajinski front diplomatije.",
     imageSrc: "/news/tramp-zelenski-oval-office.jpg",
-    imageAlt: "Donald Tramp i Volodimir Zelenski tokom sastanka u Ovalnoj kancelariji Bele kuće",
+    imageAlt:
+      "Donald Tramp i Volodimir Zelenski tokom sastanka u Ovalnoj kancelariji Bele kuće",
   },
   {
     href: "/geopolitika/mundijal-na-granici-fudbal-vize-i-politika-moci",
@@ -83,9 +85,362 @@ const ARTICLES: Article[] = [
     imageSrc: "/news/robots-ukraine.jpg",
     imageAlt: "Roboti i dronovi kao novo poglavlje rata u Ukrajini",
   },
+  {
+    href: "/geopolitika/peking-izmedju-trumpa-i-putina",
+    title: "Peking između Trumpa i Putina: Kina u središtu nove velike igre",
+    description:
+      "Putinova poseta Pekingu, samo nekoliko dana posle Trumpovog susreta sa Sijem, pokazuje kako Kina postaje centralno mesto nove velike igre između Moskve i Vašingtona.",
+    imageSrc: "/news/putin-xi.jpg",
+    imageAlt: "Vladimir Putin i Si Đinping tokom sastanka u Pekingu",
+  },
+  {
+    href: "/geopolitika/brics-iran-nafta-pukotine-multipolarnog-sveta",
+    title:
+      "BRICS pred velikim testom: Iran, nafta i pukotine multipolarnog sveta",
+    description:
+      "Sastanak ministara BRICS-a u Indiji pokazuje kako rat oko Irana, kriza nafte i Ormuski moreuz otkrivaju podele unutar multipolarnog sveta.",
+    imageSrc: "/news/brics-breaking.jpg",
+    imageAlt: "Sastanak BRICS-a i geopolitička kriza oko Irana i nafte",
+  },
+  {
+    href: "/geopolitika/ormuz-deli-nato-vasington-trazi-baze",
+    title:
+      "Ormuz deli NATO: Vašington traži baze, Evropa meri cenu savezništva",
+    description:
+      "Kriza u Ormuskom moreuzu više nije samo sukob SAD i Irana. Ona sada testira unutrašnju čvrstinu NATO-a, spremnost evropskih saveznika da podrže američke operacije i sposobnost Zapada da zaštiti ključne energetske prolaze.",
+    imageSrc: "/news/ormuz-nato-problems.jpg",
+    imageAlt: "Ormuski moreuz i NATO saveznici, ilustracija geopolitičke krize",
+  },
+  {
+    href: "/geopolitika/americke-sluzbe-iran-moze-da-izdrzi-blokadu-ormuza",
+    title:
+      "Američke službe upozoravaju: Iran može da izdrži blokadu Ormuza mesecima",
+    description:
+      "Procena američke obaveštajne zajednice dovodi u pitanje tvrdnje Bele kuće da je Teheran blizu sloma. Iran, prema tim procenama, i dalje raspolaže značajnim raketnim i dronovskim kapacitetima, dok se kriza oko Ormuskog moreuza sve jasnije pretvara u rat izdržljivosti.",
+    imageSrc: "/news/washington-cia.jpg",
+    imageAlt: "Ilustracija američke obaveštajne procene i Ormuskog moreuza",
+  },
+  {
+    href: "/geopolitika/amerika-povlaci-vojnike-iz-nemacke-nato-nepoverenje",
+    title:
+      "Amerika povlači vojnike iz Nemačke: NATO ulazi u novu eru nepoverenja",
+    description:
+      "Povlačenje oko 5.000 američkih vojnika iz Nemačke pokazuje da evropska bezbednost ulazi u period u kome se američka zaštita više ne podrazumeva kao ranije.",
+    imageSrc: "/news/us-german-soldiers-germany.jpg",
+    imageAlt:
+      "Američki i nemački vojnici tokom zajedničke vežbe u Oberlausitzu, Nemačka",
+  },
+  {
+    href: "/geopolitika/svet-na-dan-1-maj-2026",
+    title:
+      "SVET NA DAN, 1. maj: Ormuz, Ukrajina i Tajvan oblikuju novu mapu pritiska",
+    description:
+      "Prvi maj 2026. donosi sliku sveta u kome se energetska kriza, rat u Ukrajini i američko-kinesko nadmetanje sve brže spajaju u jednu geopolitičku celinu.",
+    imageSrc: "/news/world-1.may.jpg",
+    imageAlt: "Geopolitička mapa pritiska: Ormuz, Ukrajina i Tajvan",
+  },
+  {
+    href: "/geopolitika/nato-pod-pritiskom-od-saveza-ravnopravnih-ka-sistemu-uslovljene-lojalnosti",
+    title:
+      "NATO pod pritiskom: od saveza ravnopravnih ka sistemu uslovljene lojalnosti",
+    description:
+      "U Vašingtonu se sve otvorenije razmatra diferenciranje saveznika prema političkoj i vojnoj usklađenosti sa američkim prioritetima.",
+    imageSrc: "/news/Nato-new-relations.jpg",
+    imageAlt: "NATO savez pod pritiskom novih uslovljavanja",
+  },
+  {
+    href: "/geopolitika/novac-kao-uslov-trenutak-u-kojem-se-odlucuje-pravac-srbije",
+    title: "Novac kao uslov: trenutak u kojem se odlučuje pravac Srbije",
+    description:
+      "Evropska unija prvi put jasno povezuje finansijsku podršku sa političkim odlukama, otvarajući pitanje daljeg kursa Srbije.",
+    imageSrc: "/news/eu-uslov.jpg",
+    imageAlt: "Evropska unija i finansijski uslovi za političke odluke Srbije",
+  },
+  {
+    href: "/geopolitika/bugarska-na-raskrsnici-rumen-radev-vodi-prema-izlaznim-anketama",
+    title: "Bugarska na raskrsnici: Rumen Radev vodi prema izlaznim anketama",
+    description:
+      "Rezultati ukazuju na moguće pomeranje spoljnopolitičkog pravca zemlje u trenutku pojačanih tenzija između Zapada i Rusije.",
+    imageSrc: "/news/bulgaria-elections.jpg",
+    imageAlt: "Predsednički izbori u Bugarskoj",
+  },
+  {
+    href: "/geopolitika/iran-zatvara-ormuski-moreuz-svet-ulazi-u-energetsku-neizvesnost",
+    title: "Iran zatvara Ormuski moreuz: svet ulazi u energetsku neizvesnost",
+    description:
+      "Kontrola nad ključnim pomorskim pravcem postaje instrument političkog pritiska u trenutku globalnih tenzija.",
+    imageSrc: "/news/closed-again.jpg",
+    imageAlt: "Ormuski moreuz pod pojačanom vojnom kontrolom",
+  },
+  {
+    href: "/geopolitika/iran-otvorio-hormuski-moreuz-za-komercijalni-saobracaj-tokom-primirja",
+    title:
+      "Iran otvorio Ormuski moreuz za komercijalni saobraćaj tokom primirja",
+    description:
+      "Teheran je saopštio da je Ormuski moreuz otvoren za komercijalni saobraćaj tokom trajanja primirja, čime je privremeno smanjena bojazan od novog udara na globalno tržište energije.",
+    imageSrc: "/news/open-ormuz.jpg",
+    imageAlt: "Ormuski moreuz otvoren za komercijalni saobraćaj tokom primirja",
+  },
+  {
+    href: "/geopolitika/sad-odlazu-isporuke-oruzja-evropi-zbog-rata-sa-iranom",
+    title: "SAD odlažu isporuke oružja Evropi zbog rata sa Iranom",
+    description:
+      "Sjedinjene Američke Države odlažu deo planiranih isporuka oružja evropskim saveznicima zbog pojačanih operativnih zahteva u ratu sa Iranom, potvrđuju diplomatski i bezbednosni izvori.",
+    imageSrc: "/news/military-cargo.jpg",
+    imageAlt: "Vojni transport i logistika na pisti uoči isporuke opreme",
+  },
+  {
+    href: "/geopolitika/pomeranje-tezista-orban-evropa",
+    title: "POMERANJE TEŽIŠTA: Šta poraz Orbana znači za Evropu i svet",
+    description:
+      "Analiza političkih i geopolitičkih posledica poraza Viktora Orbana u Mađarskoj",
+    imageSrc: "/news/magyar.jpg",
+    imageAlt:
+      "Viktor Orban — poraz na izborima u Mađarskoj i geopolitičke posledice",
+  },
+  {
+    href: "/geopolitika/rusija-i-ukrajina-dogovorile-privremeno-primirje-za-pravoslavni-uskrs",
+    title:
+      "Rusija i Ukrajina dogovorile privremeno primirje za pravoslavni Uskrs",
+    description:
+      "Rusija i Ukrajina dogovorile su privremeni prekid vatre povodom pravoslavnog Uskrsa. Primirje je vremenski ograničeno i vezano za trajanje praznika, uz obostrane rezerve o njegovom sprovođenju na terenu.",
+    imageSrc: "/news/primirje-vaskrs.jpg",
+    imageAlt: "Ilustracija uskršnjeg primirja u ratu između Rusije i Ukrajine.",
+  },
+  {
+    href: "/geopolitika/rusija-kina-francuska-blokirale-rezoluciju-o-otvaranju-ormuskog-moreuza",
+    title:
+      "Rusija, Kina i Francuska blokirale rezoluciju o otvaranju Ormuskog moreuza",
+    description:
+      "Odluka dodatno produbljuje neizvesnost u regionu Persijskog zaliva i pojačava pritisak na globalne energetske tokove.",
+    imageSrc: "/news/un-security-council.jpg",
+    imageAlt:
+      "Savet bezbednosti Ujedinjenih nacija u Njujorku, gde je blokirana rezolucija o otvaranju Ormuskog moreuza.",
+  },
+  {
+    href: "/geopolitika/harg-srce-iranskog-izvoza-nafte",
+    title: "Harg – srce iranskog izvoza nafte",
+    description:
+      "Sjedinjene Američke Države, prema dostupnim izveštajima, izvele su udare na vojne ciljeve na ostrvu Harg, ključnom energetskom čvorištu Irana u Persijskom zalivu.",
+    imageSrc: "/news/harg-oil-terminal.jpg",
+    imageAlt:
+      "Naftni terminal na ostrvu Harg, jednom od najvažnijih energetskih čvorišta Irana.",
+  },
+  {
+    href: "/geopolitika/oboren-f15e-iran-2026",
+    title:
+      "Oboren američki F-15E iznad Irana: jedan član posade spašen, drugi nestao",
+    description:
+      "Incident predstavlja prvi potvrđeni slučaj obaranja američkog aviona sa posadom u aktuelnom sukobu",
+    imageSrc: "/news/f15e-iran.jpg",
+    imageAlt: "F-15E Strike Eagle u letu",
+  },
+  {
+    href: "/geopolitika/inflacija-evrozona-ecb-mart",
+    title: "Inflacija u evrozoni ponovo iznad cilja Evropske centralne banke",
+    description:
+      "Rast cena energije pogurao inflaciju na 2,5 odsto, dok monetarne vlasti razmatraju sledeće korake",
+    imageSrc: "/news/ecb-frankfurt-inflation.jpg",
+    imageAlt: "Sedište Evropske centralne banke u Frankfurtu, Nemačka",
+  },
+  {
+    href: "/geopolitika/vens-netanjahu-iran-rat",
+    title: "Vens kritikovao Netanjahua zbog procena rata sa Iranom",
+    description:
+      "JD Vens kritikovao Benjamina Netanjahua zbog procena rata sa Iranom, ukazujući na rastuće razlike unutar savezništva.",
+    imageSrc: "/news/vance-netanyahu.jpg",
+    imageAlt: "JD Vens i Benjamin Netanjahu tokom sastanka u Jerusalimu",
+  },
+  {
+    href: "/geopolitika/un-istraga-skola-iran",
+    title: "UN traži pravdu nakon bombardovanja škole u Iranu",
+    description:
+      "Ujedinjene nacije traže hitnu istragu nakon bombardovanja škole u Iranu u kojem je stradalo više od 150 civila.",
+    imageSrc: "/news/un-investigation.jpg",
+    imageAlt: "Zastava Ujedinjenih nacija ispred sedišta UN",
+  },
+  {
+    href: "/geopolitika/orban-prekid-gas-ukrajina",
+    title: "Orban najavio prekid isporuke gasa Ukrajini",
+    description:
+      "Mađarski premijer Viktor Orban najavio postepeni prekid isporuke gasa Ukrajini, uz nove tenzije unutar Evropske unije.",
+    imageSrc: "/news/orban-gas.jpg",
+    imageAlt: "Viktor Orban tokom obraćanja na sastanku Evropskog saveta",
+  },
+  {
+    href: "/geopolitika/nemacka-kritika-rat-iran",
+    title:
+      "Nemačka oštro kritikovala rat: „Katastrofalna greška“ i kršenje međunarodnog prava",
+    description:
+      "Nemački predsednik ocenio rat protiv Irana kao katastrofalnu grešku i upozorio na kršenje međunarodnog prava.",
+    imageSrc: "/news/Frank-Walter Steinmeier.jpg",
+    imageAlt: "Frank-Valter Štajnmajer tokom obraćanja povodom rata sa Iranom",
+  },
+  {
+    href: "/geopolitika/iran-trump-ormuski-moreuz",
+    title:
+      "Iran preti zatvaranjem Ormuskog moreuza kao odgovor na Trampov ultimatum",
+    description:
+      "Iran preti zatvaranjem Ormuskog moreuza kao odgovor na američki ultimatum, uz rizik globalne energetske krize.",
+    imageSrc: "/news/trump-iran.jpg",
+    imageAlt:
+      "Ilustracija sukoba između Donalda Trampa i Irana sa simboličnom kapljom nafte u centru, koja predstavlja globalnu energetsku i političku napetost",
+  },
+  {
+    href: "/geopolitika/meloni-referendum-italija",
+    title: "Meloni priznala poraz: Italijani odbacili reformu pravosuđa",
+    description:
+      "Italijani su na referendumu odbacili reformu pravosuđa, a premijerka Giorgia Meloni priznala poraz.",
+    imageSrc: "/news/meloni-referendum.jpg",
+    imageAlt:
+      "Giorgia Meloni tokom obraćanja nakon referenduma o reformi pravosuđa u Italiji",
+  },
+  {
+    href: "/geopolitika/ormuz-moreuz",
+    title: "Evropske zemlje i Japan o bezbednosti Ormuskog moreuza",
+    description:
+      "Evropske zemlje i Japan objavili su zajedničko saopštenje o bezbednosti Ormuskog moreuza i zaštiti pomorskih ruta za snabdevanje energentima.",
+    imageSrc: "/news/ormuz-kriza.jpg",
+    imageAlt:
+      "Naftni tanker prolazi kroz uski Ormuski moreuz kao simbol globalne energetske napetosti",
+  },
+  {
+    href: "/geopolitika/energetski-rat",
+    title:
+      "Bliski istok ulazi u energetski rat: posle napada u Zalivu nafta skače, tržišta u panici",
+    description:
+      "Napadi na energetsku infrastrukturu u Zalivu podižu cenu nafte i šire krizu na Evropu.",
+    imageSrc: "/news/nafta-kriza.jpg",
+    imageAlt:
+      "Minimalistička ilustracija točilice za gorivo kao simbol energetske krize na Bliskom istoku",
+  },
+  {
+    href: "/geopolitika/tanker-bez-pogona",
+    title:
+      "EVROPA U TRCI SA VREMENOM: tanker bez pogona preti ekološkom katastrofom",
+    description:
+      "Tanker bez pogona koji prevozi naftu nekontrolisano pluta u evropskim vodama, dok evropski lideri upozoravaju na rizik ekološke katastrofe i traže hitnu koordinisanu reakciju.",
+    imageSrc: "/news/tanker.jpg",
+    imageAlt: "Tanker bez pogona u evropskim vodama",
+  },
+  {
+    href: "/geopolitika/zapadne-sile-upozorile-izrael",
+    title:
+      "Zapadne sile upozorile Izrael - ne pokretati kopnenu ofanzivu u Libanu",
+    description:
+      "Zapadne zemlje upozoravaju Izrael da ne pokreće kopnenu operaciju u Libanu, uz rastući rizik regionalne eskalacije.",
+    imageSrc: "/news/west-against-israel.jpg",
+    imageAlt: "Zapadne sile upozorile Izrael - kopnena ofanziva u Libanu",
+  },
+  {
+    href: "/geopolitika/svetska-kriza-sve-ozbiljnija",
+    title: "SVETSKA KRIZA SVE OZBILJNIJA",
+    description: "Zašto je Ormuski moreuz tako važan",
+    imageSrc: "/news/brodovi-kriza.jpg",
+    imageAlt: "Brodovi u Ormuskom moreuzu — globalna energetska kriza",
+  },
+  {
+    href: "/geopolitika/biennale-rusija",
+    title:
+      "EU preti povlačenjem finansiranja Venecijanskog bijenala zbog mogućeg povratka Rusije",
+    description:
+      "Evropska unija zapretila je mogućnošću povlačenja finansijske podrške Venecijanskom bijenalu ukoliko Rusiji bude dozvoljen povratak na ovu prestižnu međunarodnu umetničku manifestaciju.",
+    imageSrc: "/news/biennale-venice.jpg",
+    imageAlt: "Venecijansko bijenale — povratak Rusije",
+  },
+  {
+    href: "/geopolitika/refugees-iran-un",
+    title:
+      "Rat u Iranu pokrenuo masovno raseljavanje: UN upozorava na 3,2 miliona izbeglica",
+    description:
+      "Agencija UN za izbeglice upozorava da se humanitarna kriza ubrzano širi dok milioni ljudi napuštaju svoje domove.",
+    imageSrc: "/refugees-iran-un.jpg",
+    imageAlt: "Izbeglice iz Irana — humanitarna kriza",
+  },
+  {
+    href: "/geopolitika/rezerve-nafte",
+    title: "IEA pokreće najveće oslobađanje naftnih rezervi u istoriji",
+    description:
+      "Države članice puštaju 400 miliona barela nafte iz strateških rezervi kako bi ublažile globalni energetski šok izazvan krizom u Persijskom zalivu.",
+    imageSrc: "/rezerve-nafte.jpg",
+    imageAlt: "IEA — oslobađanje strateških naftnih rezervi",
+  },
+  {
+    href: "/geopolitika/sad-specijalna-operacija-iran-uranijum",
+    title:
+      "SAD razmatraju specijalnu operaciju za preuzimanje iranskog uranijuma",
+    description:
+      "Američki bezbednosni krugovi razmatraju ograničenu vojnu operaciju usmerenu na iranske zalihe visoko obogaćenog uranijuma.",
+    imageSrc: "/us-special-forces-desert.jpg",
+    imageAlt: "Američke specijalne snage u pustinjskoj operaciji",
+  },
+  {
+    href: "/geopolitika/francuska-odbrana-ormuza",
+    title: "Evropa razmatra vojnu misiju za otvaranje Ormuskog moreuza",
+    description:
+      "Makron najavljuje odbrambenu pomorsku misiju za zaštitu slobodne plovidbe kroz ključni energetski prolaz.",
+    imageSrc: "/hormuz-strait-tankers.jpg",
+    imageAlt: "Tankeri u Ormuskom moreuzu",
+  },
+  {
+    href: "/geopolitika/velike-sile-i-kriza-u-iranu",
+    title: "Velike sile i kriza u Iranu: oprezna ravnoteža Moskve i Pekinga",
+    description:
+      "Između podrške Teheranu i izbegavanja velikog rata: kako Rusija i Kina balansiraju strateška partnerstva i globalne interese.",
+    imageSrc: "/russia-china-shadows.jpg",
+    imageAlt: "Rusija i Kina — senke velikih sila",
+  },
+  {
+    href: "/geopolitika/ormuz",
+    title: "Zatvoren Ormuski moreuz: svet suočen sa energetskim šokom",
+    description:
+      "Ključni pomorski prolaz za naftu pod pritiskom: poremećaji u transportu energenata i rast rizika za globalnu ekonomiju.",
+    imageSrc: "/ormuz.jpg",
+    imageAlt: "Ormuski moreuz",
+  },
+  {
+    href: "/geopolitika/sukobi-izrael-iran-2026",
+    title: "IZRAEL–IRAN: nova eskalacija i crvene linije regiona (2026)",
+    description:
+      "Šta se menja na terenu, šta u diplomatiji - i gde su granice kontrole u spirali odgovora.",
+    imageSrc: "/f22-israel-iran-2026.jpg",
+    imageAlt: "Geopolitika  -  Izrael Iran",
+  },
+  {
+    href: "/geopolitika/iran-protesti-2026",
+    title:
+      "IRAN: Protesti zahvatili najmanje 10 univerziteta, BBC potvrdio snimke sukoba",
+    description:
+      "Sukobi na kampusima i pojačana represija: relevantni izveštaji govore o stotinama ubijenih u prethodnim talasima protesta.",
+    imageSrc: "/tehran-riots.jpg",
+    imageAlt: "Geopolitika  -  Iran protesti",
+  },
+  {
+    href: "/geopolitika/ukrajina-cetiri-godine-rata",
+    title: "Četiri godine rata: šta sada određuje cenu mira",
+    description:
+      "Dve perspektive, jedan horizont: rat traje, ali se menja logika odluka - i pragovi rizika.",
+    imageSrc: "/geopolitika-ukrajina.jpg",
+    imageAlt: "Geopolitika  -  Ukrajina",
+  },
+  {
+    href: "/geopolitika/nova-bezbednosna-arhitektura",
+    title:
+      "Nova bezbednosna arhitektura Evrope: da li se rađa kontinent tvrde moći?",
+    description:
+      "Rat u Ukrajini, energija i strateška autonomija - Evropa menja bezbednosni identitet.",
+    imageSrc: "/geopolitika-ukrajina.jpg",
+    imageAlt: "Nova bezbednosna arhitektura Evrope",
+  },
 ];
 
-function ArticleCard({ article, featured = false }: { article: Article; featured?: boolean }) {
+function ArticleCard({
+  article,
+  featured = false,
+}: {
+  article: Article;
+  featured?: boolean;
+}) {
   const { theme } = useTheme();
   const isDark = theme === "dark";
 

--- a/client/src/pages/NasaPlanetaIndex.tsx
+++ b/client/src/pages/NasaPlanetaIndex.tsx
@@ -102,6 +102,172 @@ const ARTICLES: NasaPlanetaArticle[] = [
     description:
       "Stiven Spilberg poručio je na CinemaConu da Holivud mora da preispita oslanjanje na franšize i nastavke, jer publika sve više traži originalne priče.",
   },
+  {
+    href: "/nasa-planeta/nasa-anounce",
+    img: "/news/nasa-anounce.jpg",
+    alt: "Ilustracija NASA misija ka Mesecu i plana trajne baze",
+    imageCredit: "Ilustracija",
+    title: "NASA najavila nove misije ka Mesecu i plan trajne baze",
+    description:
+      "Američka svemirska agencija predstavila je detaljan plan izgradnje trajne baze na Mesecu, uz seriju novih posadnih misija koje bi postepeno izgradile lunarnu infrastrukturu.",
+  },
+  {
+    href: "/nasa-planeta/trump-otvorio-ufo-arhive",
+    img: "/news/ufo-files.jpg",
+    alt: "Ilustracija UFO arhiva Trumpove administracije",
+    imageCredit: "Ilustracija: Novi Talas",
+    title: "Trump otvorio UFO arhive: više pitanja nego odgovora",
+    description:
+      "Objavljena je prva grupa američkih dokumenata o UFO i UAP pojavama. Arhive donose snimke, fotografije i stare izveštaje, ali ne i dokaz o vanzemaljskoj tehnologiji.",
+  },
+  {
+    href: "/nasa-planeta/na-marsu-otkrivene-molekule-povezane-sa-poreklom-zivota",
+    img: "/news/mars-life.jpg",
+    alt: "Površina Marsa sa tragovima organskih jedinjenja",
+    imageCredit: "NOVI TALAS / ilustracija",
+    title: "Na Marsu otkrivene molekule povezane sa poreklom života",
+    description:
+      "Rover Curiosity identifikovao je kompleksne organske molekule koji otvaraju nova pitanja o mogućem nastanku života na Crvenoj planeti.",
+  },
+  {
+    href: "/nasa-planeta/artemis-ii-splashdown",
+    img: "/news/artemis-landing.jpg",
+    alt: "Letelica Orion tokom povratka na Zemlju — misija Artemis II",
+    title:
+      "Artemis II uspešno okončan: Orion se vratio na Zemlju nakon istorijskog leta oko Meseca",
+    description:
+      "Kapsula sa četvoročlanom posadom bezbedno je sletela u Tihi okean, završivši prvu ljudsku misiju ka Mesecu posle više od 50 godina.",
+  },
+  {
+    href: "/nasa-planeta/artemis-ii-fotografije-dubokog-svemira",
+    img: "/news/orion-earth-view.jpg",
+    alt: "Pogled na Zemlju iz letelice Orion tokom misije Artemis II",
+    title:
+      "Fotografije iz dubokog svemira: Artemis II beleži prizore sa lunarnog preleta",
+    description:
+      "NASA objavila nove snimke Zemlje i pomračenja iz perspektive misije Artemis II.",
+  },
+  {
+    href: "/nasa-planeta/artemis-ii-rekord-udaljenosti",
+    img: "/news/moon-nasa.jpg",
+    alt: "Letelica Orion u dubokom svemiru tokom misije Artemis II",
+    title:
+      "Čovečanstvo najdalje od Zemlje u istoriji: Artemis II nadmašio rekord Apola 13",
+    description:
+      "Posada misije Artemis II dostigla je najveću udaljenost od Zemlje ikada zabeleženu za ljudsku posadu, premašivši rekord misije Apollo 13.",
+  },
+  {
+    href: "/nasa-planeta/artemis-ii-uzivo-prenos-rekord",
+    img: "/news/artemis-view1.jpg",
+    alt: "NASA Artemis II — uživo prenos iz dubokog svemira",
+    title:
+      "Uživo: Artemis II obara istorijski rekord — prenos iz dubokog svemira",
+    description:
+      "NASA uživo prenosi misiju Artemis II u trenutku kada posada dostiže najveću udaljenost od Zemlje u istoriji čovečanstva.",
+  },
+  {
+    href: "/nasa-planeta/artemis-ii-orion-polovina-puta-do-meseca",
+    img: "/news/artemis-view2.jpg",
+    alt: "Orion letelica na putu ka Mesecu — misija Artemis II",
+    title:
+      "Orion više od polovine puta do Meseca: misija Artemis II u dubokom svemiru",
+    description:
+      "Orion je više od polovine puta do Meseca. Misija Artemis II ulazi u fazu dubokog svemirskog krstarenja.",
+  },
+  {
+    href: "/nasa-planeta/breaking-nasa-artemis-ii-mesec-posle-50-godina",
+    img: "/news/artemis-eclipse.jpg",
+    alt: "NASA Artemis II — prva ljudska misija ka Mesecu posle 50 godina",
+    title:
+      "BREAKING: NASA ponovo šalje ljude ka Mesecu posle više od 50 godina",
+    description:
+      "Artemis II označava povratak čovečanstva u duboki svemir — prvi put od 1972. godine.",
+  },
+  {
+    href: "/nasa-planeta/moon-ring",
+    img: "/news/moon-ring.jpg",
+    alt: "Solarni prsten oko Meseca — japanski koncept svemirske energije",
+    title: "Plan iz Japana: solarni prsten oko Meseca za energiju Zemlje",
+    description:
+      "Japanski istraživački tim predstavio je koncept izgradnje ogromnog solarnog sistema na Mesecu, koji bi mogao neprekidno da proizvodi energiju i šalje je na Zemlju.",
+  },
+  {
+    href: "/nasa-planeta/psihologija-dosada",
+    img: "/news/psihologija-dosada.jpg",
+    alt: "Čovek koji sedi u tišini i gleda u daljinu — simbol mentalne odmorenosti i dosade kao produktivnog stanja",
+    title:
+      "Otkriće psihologije: zašto je najbolja stvar koju možete da uradite da ne radite ništa",
+    description:
+      "Savremena psihologija otkriva da vaš mozak najbolje radi kada ga ostavite na miru — i da je dosada možda najproduktivnija stvar koju ćete danas uraditi.",
+  },
+  {
+    href: "/nasa-planeta/najtoplija-decenija-planeta-un",
+    img: "/news/world-heat.jpg",
+    alt: "Zemlja sa tankom crvenom linijom koja simbolizuje rast globalne temperature",
+    title:
+      "UN potvrdio: planeta iza sebe ima najtopliju deceniju u istoriji merenja",
+    description:
+      "Svetska meteorološka organizacija UN potvrdila je da je period od 2015. do 2025. bio najtopliji otkad se vodi moderna evidencija o temperaturama.",
+  },
+  {
+    href: "/nasa-planeta/ai-superaplikacija",
+    img: "/news/ai-superapp.jpg",
+    alt: "Minimalistički prikaz veštačke inteligencije kao centralnog sistema koji povezuje digitalne funkcije računara",
+    title:
+      "OpenAI razvija „superaplikaciju“ koja objedinjuje ChatGPT, Codex i browser",
+    description:
+      "OpenAI planira razvoj jedinstvene desktop aplikacije koja bi objedinjavala ChatGPT, programerski alat Codex i AI browser u jedan integrisani sistem.",
+  },
+  {
+    href: "/nasa-planeta/mars-reka",
+    img: "/news/mars-reka.jpg",
+    alt: "Površina Marsa sa tragovima drevnog rečnog korita",
+    title:
+      "Na Marsu otkriveni tragovi drevne reke: nova faza u potrazi za životom",
+    description:
+      "NASA-in rover otkrio je nove dokaze koji ukazuju da je na površini Marsa nekada postojala reka, što dodatno menja dosadašnje razumevanje istorije Crvene planete.",
+  },
+  {
+    href: "/nasa-planeta/ko-je-dobio-oskara",
+    img: "/news/oscar-world.jpg",
+    alt: "Ceremonija dodele Oskara — 98. dodela nagrada Američke filmske akademije",
+    title: "Ko je dobio Oskara?",
+    description:
+      "Dok svet tone u ratove, razaranja i očigledan pad civilizacijskih normi, ceremonija Oskara nastavlja da blista, gotovo ravnodušna prema vremenu koje izgleda poraženo.",
+  },
+  {
+    href: "/nasa-planeta/kina-mozgani-implantat",
+    img: "/news/china-brain.jpg",
+    alt: "Kina — prvi moždani implantat za komercijalnu upotrebu",
+    title: "Kina odobrila prvi moždani implantat za komercijalnu upotrebu",
+    description:
+      "Kineske vlasti odobrile su prvi moždani implantat namenjen komercijalnoj upotrebi, čime je napravljen značajan korak u razvoju brain-computer interface tehnologije.",
+  },
+  {
+    href: "/nasa-planeta/kubrick",
+    img: "/kubrick.jpg",
+    alt: "Stenli Kjubrik — reditelj koji je promenio film",
+    title: "Stenli Kjubrik i tajna filma koji ne stari",
+    description:
+      "Dok se svet ponovo okreće ceremoniji Oskara, jedan reditelj i dalje stoji izvan logike nagrada i podseća nas da film može biti umetnost mišljenja.",
+  },
+  {
+    href: "/nasa-planeta/ai-vest-svest",
+    img: "/ai-supercomputer-data-center.jpg",
+    alt: "AI supercomputer data center",
+    title: "Da li je veštačka inteligencija već svesna?",
+    description:
+      "Direktor kompanije Anthropic izjavio je da naučnici sve ozbiljnije razmatraju mogućnost da napredni AI sistemi razviju neku vrstu svesti.",
+  },
+  {
+    href: "/nasa-planeta/naucnici-poceli-da-usmeravaju-snove",
+    img: "/snovi-usmeravanje-snova.jpg",
+    alt: "Naučnici usmeravaju snove",
+    title:
+      "Naučnici počeli da usmeravaju snove: novo otkriće savremene psihologije",
+    description:
+      "Novo istraživanje pokazuje da je moguće uticati na sadržaj snova i podstaći mozak da tokom sna kreativnije rešava probleme.",
+  },
 ];
 
 export default function NasaPlanetaIndex() {
@@ -158,7 +324,9 @@ export default function NasaPlanetaIndex() {
                   decoding="async"
                 />
               </div>
-              <p className="photo-credit">{hero.imageCredit || "Foto: Arhiva"}</p>
+              <p className="photo-credit">
+                {hero.imageCredit || "Foto: Arhiva"}
+              </p>
 
               <div className="max-w-[760px]">
                 <div


### PR DESCRIPTION
### Motivation
- Recent edits accidentally removed many article cards from the `Naša planeta` and `Geopolitika` section index arrays, causing only ~9 and ~8 visible cards respectively.  
- The intent is to restore all previously listed article cards (without deleting any `article` files) and keep the newest promoted stories on top.  
- Maintain unique `href` entries, avoid duplications, and do not change header/search/mobile header/Home layout code.

### Description
- Restored missing article objects into `client/src/pages/NasaPlanetaIndex.tsx` and `client/src/pages/GeopolitikaIndex.tsx`, re-adding older cards beneath the current newest stories.  
- Ensured the newest ordering is preserved: `Naša planeta` lead remains the Etruscan/`etrurska grobnica` story and `Geopolitika` keeps the Ormuski moreuz + Tramp/Putin/Ukrajina items at the top.  
- De-duplicated hrefs and merged items from the older index versions so every article `href` is unique and any existing article files remain referenced in the section arrays.  
- Only the two section index files were changed; header, search, mobile header and Home layout were left untouched (`client/src/pages/NasaPlanetaIndex.tsx`, `client/src/pages/GeopolitikaIndex.tsx`).

### Testing
- Ran code formatting with `pnpm exec prettier --write client/src/pages/NasaPlanetaIndex.tsx client/src/pages/GeopolitikaIndex.tsx` which completed successfully.  
- Ran type checks with `pnpm check` (`tsc --noEmit`) which passed with no errors.  
- Ran production build with `pnpm build` which completed successfully (site built, 103 pre-rendered SEO pages generated and `dist/public/sitemap.xml` written) despite non-blocking bundle size/env warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308eadcf34832586b785cf090e3a37)