### PR TITLE
Move Orban article to April position in Geopolitika index

### DIFF
--- a/client/src/pages/GeopolitikaIndex.tsx
+++ b/client/src/pages/GeopolitikaIndex.tsx
@@ -27,15 +27,6 @@ const ARTICLES: Article[] = [
       "Senka Viktora Orbana ispred mađarskog parlamenta, simbol kraja jedne političke ere",
   },
   {
-    href: "/geopolitika/pomeranje-tezista-orban-evropa",
-    title: "POMERANJE TEŽIŠTA: Šta poraz Orbana znači za Evropu i svet",
-    description:
-      "Analiza političkih i geopolitičkih posledica poraza Viktora Orbana u Mađarskoj i promene ravnoteže unutar Evropske unije.",
-    imageSrc: "/news/magyar.jpg",
-    imageAlt:
-      "Viktor Orban — poraz na izborima u Mađarskoj i geopolitičke posledice",
-  },
-  {
     href: "/geopolitika/sad-i-iran-blizu-sporazuma-pakistan-tvrdi-da-je-tekst-dogovoren-teheran-jos-oprezan",
     title:
       "SAD i Iran postigli okvirni mirovni dogovor: Ormuski moreuz ponovo se otvara za svetsku trgovinu",
@@ -156,6 +147,15 @@ const ARTICLES: Article[] = [
       "Prvi maj 2026. donosi sliku sveta u kome se energetska kriza, rat u Ukrajini i američko-kinesko nadmetanje sve brže spajaju u jednu geopolitičku celinu.",
     imageSrc: "/news/world-1.may.jpg",
     imageAlt: "Geopolitička mapa pritiska: Ormuz, Ukrajina i Tajvan",
+  },
+  {
+    href: "/geopolitika/pomeranje-tezista-orban-evropa",
+    title: "POMERANJE TEŽIŠTA: Šta poraz Orbana znači za Evropu i svet",
+    description:
+      "Analiza političkih i geopolitičkih posledica poraza Viktora Orbana u Mađarskoj i promene ravnoteže unutar Evropske unije.",
+    imageSrc: "/news/magyar.jpg",
+    imageAlt:
+      "Viktor Orban — poraz na izborima u Mađarskoj i geopolitičke posledice",
   },
   {
     href: "/geopolitika/nato-pod-pritiskom-od-saveza-ravnopravnih-ka-sistemu-uslovljene-lojalnosti",


### PR DESCRIPTION
### Motivation
- Reorder the Geopolitika listing so the article "POMERANJE TEŽIŠTA: Šta poraz Orbana znači za Evropu i svet" appears in the April 2026 section below newer June entries and alongside older April items.

### Description
- Modified only `client/src/pages/GeopolitikaIndex.tsx` to remove the target article object from its original position and reinsert it after the `"SVET NA DAN, 1. maj"` entry. 
- Preserved the article `href`, `title`, `description`, `imageSrc`, and `imageAlt` exactly and did not delete or alter any other articles. 
- Kept the total number of entries in the `ARTICLES` array unchanged.

### Testing
- Ran `git diff --check` to validate there are no whitespace or formatting issues and it passed. 
- Executed a small Python check that counts `href` occurrences and the target article key to confirm the `ARTICLES` array still contains the same total (`49`) entries and exactly one occurrence of the moved article, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31bb45aa2c8325b0b86ff3d5452dae)