### PR TITLE
Nova Geopolitika vest: London kampanja protiv dezinformacija

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,7 @@ import PutinGovoriOKrajuRataUkrajina from "./pages/putin-govori-o-kraju-rata-ukr
 import BricsIranNaftaPukotineMultipolarnogSveta from "./pages/brics-iran-nafta-pukotine-multipolarnog-sveta";
 import PekingIzmedjuTrumpaIPutina from "./pages/peking-izmedju-trumpa-i-putina";
 import EvropaTraziNovuFormuluZaUkrajinu from "./pages/evropa-trazi-novu-formulu-za-ukrajinu";
+import LondonDisinformationCampaignArticle from "./pages/LondonDisinformationCampaignArticle";
 
 import UkrajinaCetiriGodine from "./pages/ukrajina-cetiri-godine-rata";
 import IranProtesti2026 from "./pages/iran-protesti-2026";
@@ -539,6 +540,11 @@ function Router() {
         <Route
           path="/geopolitika/velike-sile-i-kriza-u-iranu"
           component={VelikeSileIKrizaUIranu}
+        />
+
+        <Route
+          path="/geopolitika/london-kampanja-protiv-dezinformacija"
+          component={LondonDisinformationCampaignArticle}
         />
 
         <Route path="/geopolitika" component={GeopolitikaIndex} />

--- a/client/src/pages/GeopolitikaIndex.tsx
+++ b/client/src/pages/GeopolitikaIndex.tsx
@@ -18,6 +18,15 @@ type Article = {
 
 const ARTICLES: Article[] = [
   {
+    href: "/geopolitika/london-kampanja-protiv-dezinformacija",
+    title: "London pokreće kampanju od 7 miliona funti protiv dezinformacija",
+    description:
+      "Gradske vlasti tvrde da koordinisane kampanje na društvenim mrežama narušavaju ugled britanske prestonice, zbog čega je pokrenut međunarodni program za promociju Londona i suzbijanje dezinformacija.",
+    imageSrc: "/news/london-disinformation-campaign.jpg",
+    imageAlt:
+      "London skyline with digital message overlays symbolizing disinformation campaigns",
+  },
+  {
     href: "/geopolitika/madjarska-ogranicenje-mandata-orban",
     title: "Kraj jedne ere: Mađarska zatvara vrata Orbanovom povratku",
     description:

--- a/client/src/pages/LondonDisinformationCampaignArticle.tsx
+++ b/client/src/pages/LondonDisinformationCampaignArticle.tsx
@@ -1,0 +1,30 @@
+import ArticleTemplate from "@/components/ArticleTemplate";
+
+const PARAGRAPHS = [
+  "Gradonačelnik Londona Sadiq Khan predstavio je novu međunarodnu kampanju vrednu sedam miliona funti, čiji je cilj da se suprotstavi širenju dezinformacija o britanskoj prestonici i istovremeno ojača njen međunarodni ugled kao centra kulture, obrazovanja, turizma i investicija.",
+  "Program bi trebalo da bude pokrenut tokom jeseni i biće usmeren prema publici u Evropi, Severnoj Americi i Aziji. Prema navodima gradskih vlasti, kampanja predstavlja odgovor na sve veći broj sadržaja na društvenim mrežama koji London prikazuju kao grad u stalnom bezbednosnom, ekonomskom i društvenom padu.",
+  "U saopštenju kancelarije gradonačelnika navodi se da su pojedine negativne kampanje poslednjih godina dostigle milionske preglede, pri čemu su često korišćene manipulativne fotografije, selektivno prikazani događaji ili sadržaji generisani veštačkom inteligencijom. Gradske vlasti tvrde da takvi narativi mogu imati direktan uticaj na odluke turista, investitora i međunarodnih kompanija.",
+  "London je i dalje jedna od najposećenijih svetskih metropola i jedno od najvažnijih finansijskih središta Evrope. Ipak, gradska administracija smatra da se u digitalnom prostoru vodi sve intenzivnija borba za kontrolu javne percepcije velikih gradova, država i institucija.",
+  "Khan je ocenio da se dezinformacije danas ne šire samo iz političkih razloga, već da su postale deo šire industrije koja profitira od polarizacije, straha i privlačenja pažnje na društvenim mrežama. Prema njegovim rečima, odgovor na takve pojave ne može biti samo demantovanje pojedinačnih netačnih tvrdnji, već i aktivna promocija proverenih informacija i pozitivnih primera.",
+  "Međutim, inicijativa je izazvala i kritike dela opozicionih političara i komentatora. Oni tvrde da bi gradske vlasti trebalo da se usredsrede na konkretne probleme poput kriminala, troškova života i javnih usluga, umesto na kampanje za unapređenje imidža Londona. Pojedini kritičari upozoravaju i da borba protiv dezinformacija ne sme postati izgovor za ograničavanje legitimne javne kritike.",
+  "Rasprava koja se vodi u Velikoj Britaniji odražava širi globalni trend. Vlade, međunarodne organizacije i lokalne administracije širom sveta sve više ulažu sredstva u suzbijanje dezinformacija, dok istovremeno raste zabrinutost da bi takve inicijative mogle otvoriti pitanja o granicama slobode izražavanja i kontroli digitalnog prostora.",
+  "U vremenu kada se informacije šire brže nego ikada, izazov za demokratska društva ostaje isti: kako zaštititi javnost od namernih manipulacija, a da se pritom ne ugroze otvorena rasprava i sloboda mišljenja.",
+];
+
+export default function LondonDisinformationCampaignArticle() {
+  return (
+    <ArticleTemplate
+      path="/geopolitika/london-kampanja-protiv-dezinformacija"
+      sectionLabel="Geopolitika"
+      title="London pokreće kampanju od 7 miliona funti protiv dezinformacija"
+      dateLabel="17. jun 2026."
+      deck="Gradske vlasti tvrde da koordinisane kampanje na društvenim mrežama narušavaju ugled britanske prestonice, zbog čega je pokrenut međunarodni program za promociju Londona i suzbijanje dezinformacija."
+      imageSrc="/news/london-disinformation-campaign.jpg"
+      imageAlt="London skyline with digital message overlays symbolizing disinformation campaigns"
+      imageCredit="AI generated illustration / Novi Talas"
+      paragraphs={PARAGRAPHS}
+      backHref="/geopolitika"
+      backLabel="← Nazad na Geopolitiku"
+    />
+  );
+}

--- a/shared/articleMeta.ts
+++ b/shared/articleMeta.ts
@@ -143,6 +143,15 @@ export function buildJsonLd(meta: {
  */
 export const articleMeta: ArticleStaticMeta[] = [
   {
+    path: "/geopolitika/london-kampanja-protiv-dezinformacija",
+    title: "London pokreće kampanju od 7 miliona funti protiv dezinformacija",
+    description:
+      "Gradske vlasti tvrde da koordinisane kampanje na društvenim mrežama narušavaju ugled britanske prestonice, zbog čega je pokrenut međunarodni program za promociju Londona i suzbijanje dezinformacija.",
+    imageSrc: "/news/london-disinformation-campaign.jpg",
+    datePublished: "2026-06-17",
+    author: "Novi Talas",
+  },
+  {
     path: "/geopolitika/mundijal-na-granici-fudbal-vize-i-politika-moci",
     title: "Mundijal na granici: fudbal, vize i politika moći",
     description:


### PR DESCRIPTION
### Motivation
- Objaviti novu vest u rubrici `Geopolitika` pod novim slugom i rutom bez menjanja postojećih layout komponenti.
- Dodati stranicu koja koristi postojeći `ArticleTemplate` sa kompletnim metapodacima i slikom.
- Osigurati da se članak pojavi u listi rubrike i u SEO/share registry-ju za pre-render i deljenje.

### Description
- Dodata nova stranica-članak `client/src/pages/LondonDisinformationCampaignArticle.tsx` koja koristi `ArticleTemplate` i sadrži `path`, `sectionLabel`, `title`, `dateLabel`, `deck`, `imageSrc`, `imageAlt`, `imageCredit`, `paragraphs`, `backHref` i `backLabel`.
- U `client/src/App.tsx` dodat je import `LondonDisinformationCampaignArticle` i nova `Route` za `"/geopolitika/london-kampanja-protiv-dezinformacija"` bez menjanja Home/Header/Search/Mobile Header/layout-a.
- U `client/src/pages/GeopolitikaIndex.tsx` dodata je nova kartica na vrh `ARTICLES` niza sa `href`-om `"/geopolitika/london-kampanja-protiv-dezinformacija"` i istim stilom kao ostale kartice, pri čemu nijedna postojeća kartica nije uklonjena.
- U `shared/articleMeta.ts` dodat je unos metadata za SEO/share preview sa `path`, `title`, `description`, `imageSrc`, `datePublished` i `author`.

### Testing
- Pokrenuto `pnpm exec prettier --write client/src/pages/LondonDisinformationCampaignArticle.tsx client/src/App.tsx client/src/pages/GeopolitikaIndex.tsx shared/articleMeta.ts` — uspešno.
- Pokrenuto `pnpm check` (`tsc --noEmit`) — uspešno.
- Pokrenuto `pnpm build` — uspešno; build je emitovao postojeća Vite upozorenja o nedefinisanim `%VITE_ANALYTICS_*%` env promenljivama i chunk-size warning, ali build i generisanje SEO stranica su prošli (generisano 104 SEO stranice, uključujući novu rutu).
- Pokrenuto `git diff --check` — uspešno.
- Verifikovano da je broj `Geopolitika` kartica porastao sa 49 na 50 i da nema duplih `href`-ova.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32551dab6c8325b883a3c1b2ee359a)