### PR TITLE
Add London story to Home

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -21,15 +21,14 @@ const HERO_ARTICLE = {
 
 const ARTICLES = [
   {
-    href: "/geopolitika/sad-i-iran-blizu-sporazuma-pakistan-tvrdi-da-je-tekst-dogovoren-teheran-jos-oprezan",
+    href: "/geopolitika/london-kampanja-protiv-dezinformacija",
     category: "Geopolitika",
-    title:
-      "SAD i Iran postigli okvirni mirovni dogovor: Ormuski moreuz ponovo se otvara za svetsku trgovinu",
+    title: "London pokreće kampanju od 7 miliona funti protiv dezinformacija",
     description:
-      "Donald Tramp je objavio da je dogovor sa Teheranom završen i naredio ukidanje američke pomorske blokade, ali ključna pitanja ostaju otvorena.",
-    imageSrc: "/news/ormuski-moreuz-nasa.jpg",
+      "Gradske vlasti tvrde da koordinisane kampanje na društvenim mrežama narušavaju ugled britanske prestonice, zbog čega je pokrenut međunarodni program za promociju Londona i suzbijanje dezinformacija.",
+    imageSrc: "/news/london-disinformation-campaign.jpg",
     imageAlt:
-      "Satelitski prikaz Ormuskog moreuza između Irana, Omana i Ujedinjenih Arapskih Emirata",
+      "London skyline with digital message overlays symbolizing disinformation campaigns",
   },
   {
     href: "/nasa-planeta/homerova-ilijada-pronadjena-u-egipatskoj-mumiji",


### PR DESCRIPTION
### Motivation

* Add an existing article “London pokreće kampanju od 7 miliona funti protiv dezinformacija” as a secondary (side) story on the Home page by replacing one existing side card without changing the number of cards or the hero/layout.
* Use the already-existing route and article/SEO metadata at `/geopolitika/london-kampanja-protiv-dezinformacija` so the Home page links to the canonical article.

### Description

* Edited only `client/src/pages/Home.tsx` to replace one item in the `ARTICLES` array with the London story (updated `href`, `title`, `description`, `imageSrc`, and `imageAlt`).
* Did not modify `HERO_ARTICLE`, layout components, article files, `articleMeta`, or any other files; the route and `LondonDisinformationCampaignArticle` component were already present.
* Committed the single-file change and created the PR titled "Add London story to Home".

### Testing

* Attempted to sync with `origin/main` using `git fetch origin main && git merge origin/main --ff-only`, which failed due to a missing `origin` remote in this environment. (sync step could not be completed here.)
* Ran `pnpm exec prettier --write client/src/pages/Home.tsx`, which completed successfully.
* Ran `pnpm check` (`tsc --noEmit`) and `pnpm build` (Vite build + SEO generation), both of which completed successfully and the build generated the pre-rendered SEO page for `/geopolitika/london-kampanja-protiv-dezinformacija`.
* Ran `git diff --check` and `git diff --name-only` which showed only `client/src/pages/Home.tsx` was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a327253b1288325b48eb2abbff244f4)