### PR TITLE
Set G7 article as Home hero

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,26 +10,26 @@ import Footer from "@/components/Footer";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const HERO_ARTICLE = {
-  href: "/geopolitika/madjarska-ogranicenje-mandata-orban",
+  href: "/geopolitika/g7-podrzala-sporazum-sad-iran",
   category: "Geopolitika",
-  title: "Kraj jedne ere: Mađarska zatvara vrata Orbanovom povratku",
+  title:
+    "G7 podržala sporazum SAD i Irana: otvara li se put ka trajnoj stabilizaciji Bliskog istoka?",
   description:
-    "Mađarski parlament usvojio je ustavni amandman kojim se mandat premijera ograničava na osam godina, otvarajući pitanje da li se završava politička epoha Viktora Orbana.",
-  imageSrc: "/news/orban-era-end-hungary.jpg",
-  imageAlt: "Mađarski parlament i politička senka Viktora Orbana",
+    "Lideri G7 podržali su sporazum Vašingtona i Teherana kojim je zaustavljena najnovija eskalacija u Persijskom zalivu, ali ostaje neizvesno da li dogovor može prerasti u trajniju stabilizaciju Bliskog istoka.",
+  imageSrc: "/news/g7-supports-us-iran-deal.jpg",
+  imageAlt:
+    "Minimalist editorial illustration of G7 support for a US-Iran agreement, with a stylized Middle East map and summit table",
 };
 
 const ARTICLES = [
   {
-    href: "/geopolitika/g7-podrzala-sporazum-sad-iran",
+    href: "/geopolitika/madjarska-ogranicenje-mandata-orban",
     category: "Geopolitika",
-    title:
-      "G7 podržala sporazum SAD i Irana: otvara li se put ka trajnoj stabilizaciji Bliskog istoka?",
+    title: "Kraj jedne ere: Mađarska zatvara vrata Orbanovom povratku",
     description:
-      "Lideri G7 podržali su sporazum Vašingtona i Teherana kojim je zaustavljena najnovija eskalacija u Persijskom zalivu, ali ostaje neizvesno da li dogovor može prerasti u trajniju stabilizaciju Bliskog istoka.",
-    imageSrc: "/news/g7-supports-us-iran-deal.jpg",
-    imageAlt:
-      "Minimalist editorial illustration of G7 support for a US-Iran agreement, with a stylized Middle East map and summit table",
+      "Mađarski parlament usvojio je ustavni amandman kojim se mandat premijera ograničava na osam godina, otvarajući pitanje da li se završava politička epoha Viktora Orbana.",
+    imageSrc: "/news/orban-era-end-hungary.jpg",
+    imageAlt: "Mađarski parlament i politička senka Viktora Orbana",
   },
   {
     href: "/nasa-planeta/homerova-ilijada-pronadjena-u-egipatskoj-mumiji",


### PR DESCRIPTION
### Motivation

- Promote the already-published G7 article to the Home page hero while preserving the existing Home layout and card count. 
- Keep all layout and style behavior unchanged by limiting the change to a single data swap in the Home page.

### Description

- Replaced the `HERO_ARTICLE` object in `client/src/pages/Home.tsx` with the G7 article at path `/geopolitika/g7-podrzala-sporazum-sad-iran` and image `/news/g7-supports-us-iran-deal.jpg`.
- Moved the previous hero entry into `ARTICLES[0]` so the previous hero becomes the first article card.
- Only the file `client/src/pages/Home.tsx` was modified and no layout, styling, or card count changes were made.

### Testing

- Verified the change set by running `git diff --name-only`, which returned exactly `client/src/pages/Home.tsx` before formatting/build checks. 
- Ran `pnpm exec prettier --write client/src/pages/Home.tsx` and `pnpm check` (TypeScript), both of which completed successfully. 
- Ran `pnpm build`, which completed successfully and pre-rendered SEO pages including `/geopolitika/g7-podrzala-sporazum-sad-iran`. 
- Ran `git diff --check` and there were no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32c8b95fd883259d09c517a11297ad)