### PR TITLE
Postavljanje nove G7 analize kao HERO na Home i ispravka photo credita

### DIFF
--- a/client/src/pages/G7GeopoliticalStrategyArticle.tsx
+++ b/client/src/pages/G7GeopoliticalStrategyArticle.tsx
@@ -26,7 +26,7 @@ export default function G7GeopoliticalStrategyArticle() {
       deck="Lideri najrazvijenijih zapadnih ekonomija poslali su sa samita G7 poruku da ulaze u novu fazu geopolitičkog nadmetanja — kroz smanjenje zavisnosti od kineskih sirovina, nastavak podrške Ukrajini i podršku sporazumu između SAD i Irana."
       imageSrc="/news/g7-summit-evian-2026.jpg"
       imageAlt="Leaders of G7 countries during the 2026 summit in Évian, France"
-      imageCredit="European Council / Council of the EU"
+      imageCredit="European Council / Council of the European Union, G7 Summit 2026, Évian-les-Bains"
       paragraphs={PARAGRAPHS}
       backHref="/geopolitika"
       backLabel="← Nazad na Geopolitiku"

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,27 +10,27 @@ import Footer from "@/components/Footer";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const HERO_ARTICLE = {
-  href: "/geopolitika/g7-podrzala-sporazum-sad-iran",
+  href: "/geopolitika/g7-nova-geopoliticka-strategija",
   category: "Geopolitika",
   title:
-    "G7 podržala sporazum SAD i Irana: otvara li se put ka trajnoj stabilizaciji Bliskog istoka?",
+    "G7 pokreće novu geopolitičku strategiju: manje zavisnosti od Kine, veći pritisak na Rusiju i podrška sporazumu sa Iranom",
   description:
-    "Lideri G7 podržali su sporazum Vašingtona i Teherana kojim je zaustavljena najnovija eskalacija u Persijskom zalivu, ali ostaje neizvesno da li dogovor može prerasti u trajniju stabilizaciju Bliskog istoka.",
-  imageSrc: "/news/g7-supports-us-iran-deal.jpg",
-  imageAlt:
-    "Minimalist editorial illustration of G7 support for a US-Iran agreement, with a stylized Middle East map and summit table",
+    "Lideri najrazvijenijih zapadnih ekonomija poslali su sa samita G7 poruku da ulaze u novu fazu geopolitičkog nadmetanja — kroz smanjenje zavisnosti od kineskih sirovina, nastavak podrške Ukrajini i podršku sporazumu između SAD i Irana.",
+  imageSrc: "/news/g7-summit-evian-2026.jpg",
+  imageAlt: "Leaders of G7 countries during the 2026 summit in Évian, France",
 };
 
 const ARTICLES = [
   {
-    href: "/geopolitika/g7-nova-geopoliticka-strategija",
+    href: "/geopolitika/g7-podrzala-sporazum-sad-iran",
     category: "Geopolitika",
     title:
-      "G7 pokreće novu geopolitičku strategiju: manje zavisnosti od Kine, veći pritisak na Rusiju i podrška sporazumu sa Iranom",
+      "G7 podržala sporazum SAD i Irana: otvara li se put ka trajnoj stabilizaciji Bliskog istoka?",
     description:
-      "Lideri najrazvijenijih zapadnih ekonomija poslali su sa samita G7 poruku da ulaze u novu fazu geopolitičkog nadmetanja — kroz smanjenje zavisnosti od kineskih sirovina, nastavak podrške Ukrajini i podršku sporazumu između SAD i Irana.",
-    imageSrc: "/news/g7-summit-evian-2026.jpg",
-    imageAlt: "Leaders of G7 countries during the 2026 summit in Évian, France",
+      "Lideri G7 podržali su sporazum Vašingtona i Teherana kojim je zaustavljena najnovija eskalacija u Persijskom zalivu, ali ostaje neizvesno da li dogovor može prerasti u trajniju stabilizaciju Bliskog istoka.",
+    imageSrc: "/news/g7-supports-us-iran-deal.jpg",
+    imageAlt:
+      "Minimalist editorial illustration of G7 support for a US-Iran agreement, with a stylized Middle East map and summit table",
   },
   {
     href: "/nasa-planeta/homerova-ilijada-pronadjena-u-egipatskoj-mumiji",


### PR DESCRIPTION
### Motivation
- Zameniti postojeću HERO vest na naslovnoj stranci najnovijom G7 analizom kako bi Home prikazivao najvažniju aktuelnu vest. 
- Sačuvati prethodnu G7 hero vest tako da ne nestane iz feeda i ostane lako dostupna. 
- Ispraviti i detaljnije evidentirati photo credit za sliku nove G7 analize.

### Description
- Ažuriran `client/src/pages/Home.tsx` tako da `HERO_ARTICLE` sada pokazuje na `/geopolitika/g7-nova-geopoliticka-strategija` sa novim `title`, `description`, `imageSrc` (`/news/g7-summit-evian-2026.jpg`) i `imageAlt`, a prethodna HERO vest je prebačena u `ARTICLES[0]` bez promene rasporeda ili broja sporednih kartica. 
- Ažuriran `client/src/pages/G7GeopoliticalStrategyArticle.tsx` da postavi `imageCredit` na `European Council / Council of the European Union, G7 Summit 2026, Évian-les-Bains` samo za ovu vest. 
- `shared/articleMeta.ts` je pregledan i ostavljen neizmenjen jer nije sadržao `imageCredit` za ovu vest, ali sadrži odgovarajući `path` i osnovne meta zapise. 
- Nije menjano layout ponašanje, broj kartica, Header, Search, Mobile Header, rute ili drugi article fajlovi.

### Testing
- Pokrenut `pnpm exec prettier --write client/src/pages/Home.tsx client/src/pages/G7GeopoliticalStrategyArticle.tsx shared/articleMeta.ts` i formatiranje je završeno bez problema. 
- Pokrenut `pnpm check` (TypeScript `--noEmit`) i provera je prošla bez grešaka. 
- Pokrenut `pnpm build` koji je uspešno izgradio aplikaciju i generisao SEO stranice uključujući `/geopolitika/g7-nova-geopoliticka-strategija`. 
- Pokrenuti `git diff --check` i `git diff --name-only` koji su izlistali samo `client/src/pages/Home.tsx` i `client/src/pages/G7GeopoliticalStrategyArticle.tsx` kao izmenjene datoteke; pokušaj headless screenshot-a nije uspeo zbog nedostupne `playwright` instalacije, što nije blokiralo gradnju.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33434417d48325a68315995a1bb634)