### PR TITLE
Add Geopolitika article: Prague public media protest

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,6 +28,7 @@ import EvropaTraziNovuFormuluZaUkrajinu from "./pages/evropa-trazi-novu-formulu-
 import LondonDisinformationCampaignArticle from "./pages/LondonDisinformationCampaignArticle";
 import G7UsIranAgreementArticle from "./pages/G7UsIranAgreementArticle";
 import G7GeopoliticalStrategyArticle from "./pages/G7GeopoliticalStrategyArticle";
+import PraguePublicMediaProtestArticle from "./pages/PraguePublicMediaProtestArticle";
 
 import UkrajinaCetiriGodine from "./pages/ukrajina-cetiri-godine-rata";
 import IranProtesti2026 from "./pages/iran-protesti-2026";
@@ -558,6 +559,11 @@ function Router() {
         <Route
           path="/geopolitika/g7-nova-geopoliticka-strategija"
           component={G7GeopoliticalStrategyArticle}
+        />
+
+        <Route
+          path="/geopolitika/protesti-u-pragu-zbog-finansiranja-javnog-servisa"
+          component={PraguePublicMediaProtestArticle}
         />
 
         <Route path="/geopolitika" component={GeopolitikaIndex} />

--- a/client/src/pages/GeopolitikaIndex.tsx
+++ b/client/src/pages/GeopolitikaIndex.tsx
@@ -18,6 +18,16 @@ type Article = {
 
 const ARTICLES: Article[] = [
   {
+    href: "/geopolitika/protesti-u-pragu-zbog-finansiranja-javnog-servisa",
+    title:
+      "Hiljade građana protestovale u Pragu zbog reforme finansiranja javnog servisa",
+    description:
+      "Plan češke vlade da promeni model finansiranja javnih medija izazvao je proteste u Pragu, otvarajući širu evropsku raspravu o nezavisnosti javnih servisa u digitalnom dobu.",
+    imageSrc: "/news/prague-public-media-protest.jpg",
+    imageAlt:
+      "Editorial illustration about public broadcasting, media independence and protests in Prague",
+  },
+  {
     href: "/geopolitika/g7-nova-geopoliticka-strategija",
     title:
       "G7 pokreće novu geopolitičku strategiju: manje zavisnosti od Kine, veći pritisak na Rusiju i podrška sporazumu sa Iranom",

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -22,15 +22,15 @@ const HERO_ARTICLE = {
 
 const ARTICLES = [
   {
-    href: "/geopolitika/g7-podrzala-sporazum-sad-iran",
+    href: "/geopolitika/protesti-u-pragu-zbog-finansiranja-javnog-servisa",
     category: "Geopolitika",
     title:
-      "G7 podržala sporazum SAD i Irana: otvara li se put ka trajnoj stabilizaciji Bliskog istoka?",
+      "Hiljade građana protestovale u Pragu zbog reforme finansiranja javnog servisa",
     description:
-      "Lideri G7 podržali su sporazum Vašingtona i Teherana kojim je zaustavljena najnovija eskalacija u Persijskom zalivu, ali ostaje neizvesno da li dogovor može prerasti u trajniju stabilizaciju Bliskog istoka.",
-    imageSrc: "/news/g7-supports-us-iran-deal.jpg",
+      "Plan češke vlade da promeni model finansiranja javnih medija izazvao je proteste u Pragu, otvarajući širu evropsku raspravu o nezavisnosti javnih servisa u digitalnom dobu.",
+    imageSrc: "/news/prague-public-media-protest.jpg",
     imageAlt:
-      "Minimalist editorial illustration of G7 support for a US-Iran agreement, with a stylized Middle East map and summit table",
+      "Editorial illustration about public broadcasting, media independence and protests in Prague",
   },
   {
     href: "/nasa-planeta/homerova-ilijada-pronadjena-u-egipatskoj-mumiji",

--- a/client/src/pages/PraguePublicMediaProtestArticle.tsx
+++ b/client/src/pages/PraguePublicMediaProtestArticle.tsx
@@ -1,0 +1,26 @@
+import ArticleTemplate from "@/components/ArticleTemplate";
+
+const PARAGRAPHS = [
+  "Hiljade građana okupile su se u centru Praga protestujući protiv plana češke vlade da promeni model finansiranja javnih medija. Organizatori tvrde da bi predložene izmene mogle da utiču na nezavisnost javnog servisa, dok vlast poručuje da je cilj reforme da se obezbedi stabilnije i dugoročnije finansiranje u uslovima ubrzanih promena na medijskom tržištu.",
+  "Rasprava je izazvala snažne reakcije u javnosti, jer se odnosi na medijske institucije koje imaju važnu ulogu u informisanju građana. Demonstranti smatraju da svaka promena finansijskog modela mora biti praćena jasnim garancijama uredničke nezavisnosti, dok vlada insistira da reforma ne podrazumeva politički uticaj na rad javnih emitera.",
+  "Pitanje finansiranja javnih medija poslednjih godina postaje sve aktuelnije širom Evrope. Tradicionalni sistemi pretplate nastali su u vreme kada su radio i televizija bili dominantni izvori informacija, dok danas publika sve više prati sadržaj putem digitalnih platformi, društvenih mreža i striming servisa. Zbog toga brojne države pokušavaju da pronađu model koji bi omogućio održivo finansiranje javnih servisa bez dodatnog opterećenja građana.",
+  "Istovremeno, rasprava u Češkoj otvorila je i šire pitanje odnosa između države, medija i demokratije. Zagovornici reforme tvrde da je javnim servisima potreban stabilan izvor prihoda kako bi mogli da obavljaju svoju funkciju u digitalnom dobu. Kritičari, međutim, upozoravaju da finansijska zavisnost od političkih odluka može postati izvor pritiska na uredničku autonomiju. Upravo zbog toga događaji u Pragu privlače pažnju i van granica Češke, kao deo mnogo šire evropske debate o budućnosti javnih medija.",
+];
+
+export default function PraguePublicMediaProtestArticle() {
+  return (
+    <ArticleTemplate
+      path="/geopolitika/protesti-u-pragu-zbog-finansiranja-javnog-servisa"
+      sectionLabel="Geopolitika"
+      title="Hiljade građana protestovale u Pragu zbog reforme finansiranja javnog servisa"
+      dateLabel="22. jun 2026."
+      deck="Plan češke vlade da promeni model finansiranja javnih medija izazvao je proteste u Pragu, otvarajući širu evropsku raspravu o nezavisnosti javnih servisa u digitalnom dobu."
+      imageSrc="/news/prague-public-media-protest.jpg"
+      imageAlt="Editorial illustration about public broadcasting, media independence and protests in Prague"
+      imageCredit="AI generated illustration / Novi Talas"
+      paragraphs={PARAGRAPHS}
+      backHref="/geopolitika"
+      backLabel="← Nazad na Geopolitiku"
+    />
+  );
+}

--- a/shared/articleMeta.ts
+++ b/shared/articleMeta.ts
@@ -143,6 +143,16 @@ export function buildJsonLd(meta: {
  */
 export const articleMeta: ArticleStaticMeta[] = [
   {
+    path: "/geopolitika/protesti-u-pragu-zbog-finansiranja-javnog-servisa",
+    title:
+      "Hiljade građana protestovale u Pragu zbog reforme finansiranja javnog servisa",
+    description:
+      "Plan češke vlade da promeni model finansiranja javnih medija izazvao je proteste u Pragu, otvarajući širu evropsku raspravu o nezavisnosti javnih servisa u digitalnom dobu.",
+    imageSrc: "/news/prague-public-media-protest.jpg",
+    datePublished: "2026-06-22",
+    author: "Novi Talas",
+  },
+  {
     path: "/geopolitika/g7-nova-geopoliticka-strategija",
     title:
       "G7 pokreće novu geopolitičku strategiju: manje zavisnosti od Kine, veći pritisak na Rusiju i podrška sporazumu sa Iranom",


### PR DESCRIPTION
### Motivation
- Publish a new Geopolitika article about protests in Prague with its own unique slug and route so the piece is reachable without altering existing routes.
- Surface the new article in the Geopolitika index and as a secondary card on Home while preserving `HERO_ARTICLE` and the existing editorial layout.
- Ensure the article has proper SEO/share preview data so pre-rendered meta pages and social previews include the new story.

### Description
- Added a new article page `client/src/pages/PraguePublicMediaProtestArticle.tsx` that uses `ArticleTemplate` and includes `path`, `sectionLabel`, `title`, `dateLabel`, `deck`, `imageSrc`, `imageAlt`, `imageCredit`, `paragraphs`, `backHref` and `backLabel`.
- Registered the article in the router by importing `PraguePublicMediaProtestArticle` in `client/src/App.tsx` and adding a new `<Route path="/geopolitika/protesti-u-pragu-zbog-finansiranja-javnog-servisa" component={PraguePublicMediaProtestArticle} />`.
- Inserted a card for the new article into `client/src/pages/GeopolitikaIndex.tsx` without removing any existing cards and verified there are no duplicate `href`s.
- Replaced one secondary Home card in `client/src/pages/Home.tsx` with the new article card while keeping `HERO_ARTICLE` unchanged and preserving the same number of secondary cards.
- Added an SEO/share preview entry to `shared/articleMeta.ts` for `path: "/geopolitika/protesti-u-pragu-zbog-finansiranja-javnog-servisa"` including `title`, `description`, `imageSrc`, `datePublished` and `author`.

### Testing
- Ran `pnpm exec prettier --write client/src/pages/PraguePublicMediaProtestArticle.tsx client/src/App.tsx client/src/pages/GeopolitikaIndex.tsx client/src/pages/Home.tsx shared/articleMeta.ts` and it passed.
- Ran `pnpm check` (TypeScript) and it passed without errors.
- Ran `pnpm build` and the build succeeded and generated pre-rendered SEO pages including `/geopolitika/protesti-u-pragu-zbog-finansiranja-javnog-servisa`, with Vite reporting existing environment placeholder and chunk-size warnings only.
- Ran `git diff --check` and repository/file checks that verify `GeopolitikaIndex` href count increased by one, `Home` secondary card count stayed the same, no duplicate hrefs were introduced, and only the expected files were changed, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38fb0f9d848325b207f9e0dd395a8c)