### PR TITLE
Add Vespa Rome 80th anniversary article (Naša planeta)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -242,6 +242,7 @@ import PsihologijaDosada from "./pages/psihologija-dosada";
 import NasaPredstavilaPosaduArtemisIII from "./pages/nasa-predstavila-posadu-artemis-iii";
 import StaKratkiVideoSnimciRadeDecjemMozgu from "./pages/sta-kratki-video-snimci-rade-decjem-mozgu";
 import WhyPeopleBelieveLiesArticle from "./pages/WhyPeopleBelieveLiesArticle";
+import VespaRome80Article from "./pages/VespaRome80Article";
 
 /* ✅ NOVA VEST — Naša planeta */
 import NasaAnounce from "./pages/nasa-anounce";
@@ -693,6 +694,11 @@ function Router() {
             NAŠA PLANETA
            ========================= */}
         <Route path="/nasa-planeta" component={NasaPlanetaIndex} />
+
+        <Route
+          path="/nasa-planeta/hiljade-vespi-preplavile-rim-povodom-80-godina-italijanske-ikone"
+          component={VespaRome80Article}
+        />
 
         <Route
           path="/nasa-planeta/sta-kratki-video-snimci-rade-decjem-mozgu"

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -23,14 +23,14 @@ const HERO_ARTICLE = {
 
 const ARTICLES = [
   {
-    href: "/geopolitika/g7-nova-geopoliticka-strategija",
-    category: "Geopolitika",
-    title:
-      "G7 pokreće novu geopolitičku strategiju: manje zavisnosti od Kine, veći pritisak na Rusiju i podrška sporazumu sa Iranom",
+    href: "/nasa-planeta/hiljade-vespi-preplavile-rim-povodom-80-godina-italijanske-ikone",
+    category: "Naša planeta",
+    title: "Hiljade Vespi preplavile Rim povodom 80 godina italijanske ikone",
     description:
-      "Lideri najrazvijenijih zapadnih ekonomija poslali su sa samita G7 poruku da ulaze u novu fazu geopolitičkog nadmetanja — kroz smanjenje zavisnosti od kineskih sirovina, nastavak podrške Ukrajini i podršku sporazumu između SAD i Irana.",
-    imageSrc: "/news/g7-summit-evian-2026.jpg",
-    imageAlt: "Leaders of G7 countries during the 2026 summit in Évian, France",
+      "Više hiljada vlasnika Vespi okupilo se u istorijskom centru Rima kako bi obeležili osam decenija jednog od najprepoznatljivijih simbola italijanskog dizajna, filma i urbanog života.",
+    imageSrc: "/news/vespa-rome-80th-anniversary.jpg",
+    imageAlt:
+      "Watercolor editorial illustration of the 80th anniversary Vespa parade through Rome",
   },
   {
     href: "/geopolitika/protesti-u-pragu-zbog-finansiranja-javnog-servisa",

--- a/client/src/pages/NasaPlanetaIndex.tsx
+++ b/client/src/pages/NasaPlanetaIndex.tsx
@@ -19,6 +19,15 @@ type NasaPlanetaArticle = {
 
 const ARTICLES: NasaPlanetaArticle[] = [
   {
+    href: "/nasa-planeta/hiljade-vespi-preplavile-rim-povodom-80-godina-italijanske-ikone",
+    img: "/news/vespa-rome-80th-anniversary.jpg",
+    alt: "Watercolor editorial illustration of the 80th anniversary Vespa parade through Rome",
+    imageCredit: "AI generated illustration / Novi Talas",
+    title: "Hiljade Vespi preplavile Rim povodom 80 godina italijanske ikone",
+    description:
+      "Više hiljada vlasnika Vespi okupilo se u istorijskom centru Rima kako bi obeležili osam decenija jednog od najprepoznatljivijih simbola italijanskog dizajna, filma i urbanog života.",
+  },
+  {
     href: "/nasa-planeta/zasto-ljudi-veruju-lazima",
     img: "/news/confirmation-bias-mirror.jpg",
     alt: "Minimalist mirror illustration symbolizing confirmation bias and self-deception",

--- a/client/src/pages/VespaRome80Article.tsx
+++ b/client/src/pages/VespaRome80Article.tsx
@@ -1,0 +1,26 @@
+import ArticleTemplate from "@/components/ArticleTemplate";
+
+const PARAGRAPHS = [
+  "Više hiljada ljubitelja legendarnog skutera Vespa okupilo se u istorijskom centru Rima kako bi obeležili osamdeset godina jednog od najprepoznatljivijih simbola italijanskog dizajna i kulture. Kolona skutera prošla je pored najpoznatijih rimskih trgova i znamenitosti, pretvarajući grad u veliku pokretnu izložbu modela koji su obeležili generacije vozača širom sveta.",
+  "Manifestacija je okupila učesnike iz više desetina zemalja, od vlasnika pažljivo restauriranih primeraka iz pedesetih godina do zaljubljenika u najnovije modele. Za mnoge od njih Vespa nije samo prevozno sredstvo, već deo lične istorije i simbol jednog načina života.",
+  "Priča o Vespi počela je 1946. godine, kada je italijanska kompanija Piaggio predstavila skuter namenjen jednostavnom i pristupačnom gradskom prevozu. Zahvaljujući prepoznatljivom dizajnu i praktičnosti, Vespa je ubrzo postala globalni fenomen, a njenu popularnost dodatno su učvrstili filmovi poput „Praznik u Rimu“, u kojem su Audrey Hepburn i Gregory Peck upravo na Vespi obišli ulice italijanske prestonice.",
+  "Osam decenija kasnije, ovaj skuter ostaje mnogo više od tehničkog proizvoda. On predstavlja spoj industrijskog dizajna, italijanske elegancije i kulture putovanja, zbog čega se i danas smatra jednom od najuspešnijih dizajnerskih ikona 20. veka. Jubilej u Rimu još jednom je pokazao da Vespa, uprkos vremenu i tehnološkim promenama, i dalje okuplja zajednicu ljudi koje povezuje ista ideja slobode na dva točka.",
+];
+
+export default function VespaRome80Article() {
+  return (
+    <ArticleTemplate
+      path="/nasa-planeta/hiljade-vespi-preplavile-rim-povodom-80-godina-italijanske-ikone"
+      sectionLabel="Naša planeta"
+      title="Hiljade Vespi preplavile Rim povodom 80 godina italijanske ikone"
+      dateLabel="28. jun 2026."
+      deck="Više hiljada vlasnika Vespi okupilo se u istorijskom centru Rima kako bi obeležili osam decenija jednog od najprepoznatljivijih simbola italijanskog dizajna, filma i urbanog života."
+      imageSrc="/news/vespa-rome-80th-anniversary.jpg"
+      imageAlt="Watercolor editorial illustration of the 80th anniversary Vespa parade through Rome"
+      imageCredit="AI generated illustration / Novi Talas"
+      paragraphs={PARAGRAPHS}
+      backHref="/nasa-planeta"
+      backLabel="← Nazad na Našu planetu"
+    />
+  );
+}

--- a/shared/articleMeta.ts
+++ b/shared/articleMeta.ts
@@ -143,6 +143,15 @@ export function buildJsonLd(meta: {
  */
 export const articleMeta: ArticleStaticMeta[] = [
   {
+    path: "/nasa-planeta/hiljade-vespi-preplavile-rim-povodom-80-godina-italijanske-ikone",
+    title: "Hiljade Vespi preplavile Rim povodom 80 godina italijanske ikone",
+    description:
+      "Više hiljada vlasnika Vespi okupilo se u istorijskom centru Rima kako bi obeležili osam decenija jednog od najprepoznatljivijih simbola italijanskog dizajna, filma i urbanog života.",
+    imageSrc: "/news/vespa-rome-80th-anniversary.jpg",
+    datePublished: "2026-06-28",
+    author: "Novi Talas",
+  },
+  {
     path: "/obavestajni-izvori/nemacka-menja-bnd-najveca-reforma-obavestajne-sluzbe",
     title:
       "Nemačka menja BND: najveća reforma obaveštajne službe u poslednjim decenijama",


### PR DESCRIPTION
### Motivation
- Objaviti novu vest u rubrici "Naša planeta" koristeći postojeći `ArticleTemplate` i obezbediti odgovarajuću rutu, kartice i SEO meta podatke za deljenje.
- Prikazati članak na indeksu sekcije i kao sporednu karticu na Home bez menjanja postojeće hero priče niti broja sporednih kartica.

### Description
- Dodata nova stranica članka u `client/src/pages/VespaRome80Article.tsx` koja koristi `ArticleTemplate` i sadrži naslov, deck, tekst, sliku i povratnu vezu ka `/nasa-planeta`.
- Registrisana nova ruta i import dodat u `client/src/App.tsx` za `path: "/nasa-planeta/hiljade-vespi-preplavile-rim-povodom-80-godina-italijanske-ikone"` koja renderuje `VespaRome80Article`.
- Dodata nova kartica na vrh `ARTICLES` liste u `client/src/pages/NasaPlanetaIndex.tsx` kako bi se prikazala u indeksu sekcije.
- Zamenjena jedna postojeća sporedna kartica u `client/src/pages/Home.tsx` novom Vespa karticom, pri čemu je `HERO_ARTICLE` ostao nepromenjen i broj sporednih kartica je sačuvan.
- Dodat SEO/share preview unos u `shared/articleMeta.ts` sa relativnom putanjom slike i datumom objave.

### Testing
- Pokrenuto formatiranje pomoću `pnpm exec prettier --write client/src/pages/VespaRome80Article.tsx client/src/App.tsx client/src/pages/NasaPlanetaIndex.tsx client/src/pages/Home.tsx shared/articleMeta.ts` i formatiranje je uspešno završeno.
- Pokrenuto tip-checkiranje sa `pnpm check` i `tsc --noEmit` koje je prošlo bez grešaka.
- Projekat izgrađen pomoću `pnpm build` i build je uspešno završio (generisano je i pred-renderovanih SEO stranica, uključujući novu vest).
- Pokrenuto `git diff --check` i provere integriteta radne kopije su prošle bez problema; dodatne provere su potvrdile da novi href postoji samo jednom u `NasaPlanetaIndex`, da `HERO_ARTICLE` nije izmenjen i da je nova kartica prikazana na Home.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a414446d0fc83258ffd2e4c49db5922)