### PR TITLE
Standardize Novi Talas illustration credits

### DIFF
--- a/client/src/pages/CrimeaDroneAttacksArticle.tsx
+++ b/client/src/pages/CrimeaDroneAttacksArticle.tsx
@@ -9,7 +9,7 @@ const ARTICLE = {
   imageSrc: "/news/crimea-drone-attacks.jpg",
   imageAlt:
     "Minimalist editorial illustration of Crimea following large-scale drone attacks",
-  imageCredit: "AI generated illustration / Novi Talas",
+  imageCredit: "Ilustracija / Novi Talas",
   paragraphs: [
     "Prema pisanju The Guardiana, ruske vlasti koje upravljaju anektiranim Krimom proglasile su vanrednu situaciju nakon jednog od najvećih talasa ukrajinskih napada dronovima od početka rata. List navodi da su u pojedinim delovima poluostrva zabeleženi prekidi u snabdevanju električnom energijom i poremećaji u funkcionisanju infrastrukture, dok Moskva tvrdi da je oborila veliki broj bespilotnih letelica.",
     "Ukrajina poslednjih nedelja sve češće izvodi napade na ciljeve duboko iza linije fronta. Kako prenosi Reuters, fokus je pre svega na energetskoj i logističkoj infrastrukturi, sa ciljem da se oteža snabdevanje ruskih snaga i oslabe vojni kapaciteti na okupiranim teritorijama.",

--- a/client/src/pages/G7UsIranAgreementArticle.tsx
+++ b/client/src/pages/G7UsIranAgreementArticle.tsx
@@ -22,7 +22,7 @@ export default function G7UsIranAgreementArticle() {
       deck="Lideri G7 podržali su sporazum Vašingtona i Teherana kojim je zaustavljena najnovija eskalacija u Persijskom zalivu, ali ostaje neizvesno da li dogovor može prerasti u trajniju stabilizaciju Bliskog istoka."
       imageSrc="/news/g7-supports-us-iran-deal.jpg"
       imageAlt="Minimalist editorial illustration of G7 support for a US-Iran agreement, with a stylized Middle East map and summit table"
-      imageCredit="AI generated illustration / Novi Talas"
+      imageCredit="Ilustracija / Novi Talas"
       paragraphs={PARAGRAPHS}
       backHref="/geopolitika"
       backLabel="← Nazad na Geopolitiku"

--- a/client/src/pages/GermanyBNDReformArticle.tsx
+++ b/client/src/pages/GermanyBNDReformArticle.tsx
@@ -27,7 +27,7 @@ export default function GermanyBNDReformArticle() {
       deck="Berlin priprema najopsežniju reformu Savezne obaveštajne službe u poslednjim decenijama, sa fokusom na sajber operacije, elektronsko izviđanje i veštačku inteligenciju."
       imageSrc={IMAGE_SRC}
       imageAlt="Editorial illustration about the modernization of Germany's Federal Intelligence Service (BND)"
-      imageCredit="AI generated illustration / Novi Talas"
+      imageCredit="Ilustracija / Novi Talas"
       paragraphs={PARAGRAPHS}
       backHref="/obavestajni-izvori"
       backLabel="← Nazad na Obaveštajni izvori"

--- a/client/src/pages/LondonDisinformationCampaignArticle.tsx
+++ b/client/src/pages/LondonDisinformationCampaignArticle.tsx
@@ -21,7 +21,7 @@ export default function LondonDisinformationCampaignArticle() {
       deck="Gradske vlasti tvrde da koordinisane kampanje na društvenim mrežama narušavaju ugled britanske prestonice, zbog čega je pokrenut međunarodni program za promociju Londona i suzbijanje dezinformacija."
       imageSrc="/news/london-disinformation-campaign.jpg"
       imageAlt="London skyline with digital message overlays symbolizing disinformation campaigns"
-      imageCredit="AI generated illustration / Novi Talas"
+      imageCredit="Ilustracija / Novi Talas"
       paragraphs={PARAGRAPHS}
       backHref="/geopolitika"
       backLabel="← Nazad na Geopolitiku"

--- a/client/src/pages/PraguePublicMediaProtestArticle.tsx
+++ b/client/src/pages/PraguePublicMediaProtestArticle.tsx
@@ -17,7 +17,7 @@ export default function PraguePublicMediaProtestArticle() {
       deck="Plan češke vlade da promeni model finansiranja javnih medija izazvao je proteste u Pragu, otvarajući širu evropsku raspravu o nezavisnosti javnih servisa u digitalnom dobu."
       imageSrc="/news/prague-public-media-protest.jpg"
       imageAlt="Editorial illustration about public broadcasting, media independence and protests in Prague"
-      imageCredit="AI generated illustration / Novi Talas"
+      imageCredit="Ilustracija / Novi Talas"
       paragraphs={PARAGRAPHS}
       backHref="/geopolitika"
       backLabel="← Nazad na Geopolitiku"

--- a/client/src/pages/VespaRome80Article.tsx
+++ b/client/src/pages/VespaRome80Article.tsx
@@ -17,7 +17,7 @@ export default function VespaRome80Article() {
       deck="Više hiljada vlasnika Vespi okupilo se u istorijskom centru Rima kako bi obeležili osam decenija jednog od najprepoznatljivijih simbola italijanskog dizajna, filma i urbanog života."
       imageSrc="/news/vespa-rome-80th-anniversary.jpg"
       imageAlt="Watercolor editorial illustration of the 80th anniversary Vespa parade through Rome"
-      imageCredit="AI generated illustration / Novi Talas"
+      imageCredit="Ilustracija / Novi Talas"
       paragraphs={PARAGRAPHS}
       backHref="/nasa-planeta"
       backLabel="← Nazad na Našu planetu"

--- a/client/src/pages/WhyPeopleBelieveLiesArticle.tsx
+++ b/client/src/pages/WhyPeopleBelieveLiesArticle.tsx
@@ -26,7 +26,7 @@ export default function WhyPeopleBelieveLiesArticle() {
       deck="Nova istraživanja i psihološki modeli pokazuju da ljudi ne prihvataju informacije samo na osnovu činjenica, već i na osnovu emocija, identiteta i potrebe da potvrde ono u šta već veruju."
       imageSrc="/news/confirmation-bias-mirror.jpg"
       imageAlt="Minimalist mirror illustration symbolizing confirmation bias and self-deception"
-      imageCredit="AI generated illustration / Novi Talas"
+      imageCredit="Ilustracija / Novi Talas"
       paragraphs={PARAGRAPHS}
       backHref="/nasa-planeta"
       backLabel="← Nazad na Našu planetu"


### PR DESCRIPTION
### Motivation
- Standardize the internal image credit used for author illustrations by replacing the legacy string `AI generated illustration / Novi Talas` with the localized `Ilustracija / Novi Talas`.
- Limit the change strictly to article pages that used the internal AI credit and avoid touching photos or external providers (Reuters, AP, Wikimedia, NASA, etc.).

### Description
- Replaced the credit string in 7 article files under `client/src/pages`: `CrimeaDroneAttacksArticle.tsx`, `G7UsIranAgreementArticle.tsx`, `GermanyBNDReformArticle.tsx`, `LondonDisinformationCampaignArticle.tsx`, `PraguePublicMediaProtestArticle.tsx`, `VespaRome80Article.tsx`, and `WhyPeopleBelieveLiesArticle.tsx`.
- No other image credits, photographs, layout code, or article content were modified.
- Only article files containing the exact old credit were updated; site templates and non-article pages were not changed.

### Testing
- Ran `pnpm exec prettier --write client/src/pages/*.tsx` and formatting was applied successfully.
- Ran `pnpm check` (TypeScript `tsc --noEmit`) and it passed without errors.
- Ran `pnpm build` (Vite + esbuild + SEO generation) and the build completed successfully.
- Ran `git diff --check` and there were no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a414a0036788325bb9165fe90baa05c)