### PR TITLE
Add Anthropic AI governance article page and register it in routes, home and section index

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -204,6 +204,7 @@ import KoJeDobioOskara from "./pages/ko-je-dobio-oskara";
 /* ✅ NOVA VEST — Naša planeta */
 import NaucniciPoceliDaUsmeravajuSnove from "./pages/naucnici-poceli-da-usmeravaju-snove";
 import AiVestSvest from "./pages/ai-vest-svest";
+import AnthropicAIGovernanceArticle from "./pages/AnthropicAIGovernanceArticle";
 import Kubrick from "./pages/kubrick";
 import KinaMozganiImplantat from "./pages/kina-mozgani-implantat";
 
@@ -693,6 +694,11 @@ function Router() {
         {/* =========================
             NAŠA PLANETA
            ========================= */}
+        <Route
+          path="/nasa-planeta/anthropic-upozorava-da-li-razvoj-vestacke-inteligencije-postaje-brzi-od-nase-sposobnosti-da-je-kontrolisemo"
+          component={AnthropicAIGovernanceArticle}
+        />
+
         <Route path="/nasa-planeta" component={NasaPlanetaIndex} />
 
         <Route

--- a/client/src/pages/AnthropicAIGovernanceArticle.tsx
+++ b/client/src/pages/AnthropicAIGovernanceArticle.tsx
@@ -1,0 +1,27 @@
+import ArticleTemplate from "@/components/ArticleTemplate";
+
+const PARAGRAPHS = [
+  "Jedna od vodećih svetskih kompanija za razvoj veštačke inteligencije, Anthropic, upozorila je da bi napredak najmoćnijih AI sistema uskoro mogao da nadmaši postojeće bezbednosne mehanizme namenjene njihovoj kontroli. Kako prenosi Reuters, kompanija ne poziva na zaustavljanje razvoja veštačke inteligencije, već na uspostavljanje zajedničkog međunarodnog sistema koji bi omogućio privremeno usporavanje razvoja ukoliko rizici postanu preveliki.",
+  "Predlog dolazi u trenutku kada vodeće tehnološke kompanije razvijaju sve sposobnije AI modele, dok istovremeno raste zabrinutost da regulatorni okvir ne prati brzinu tehnoloških promena. Anthropic smatra da bi najveće AI laboratorije trebalo da unapred definišu jasna pravila i bezbednosne procedure koje bi se aktivirale ukoliko budući sistemi dostignu nivo koji zahteva dodatne provere.",
+  "Prema pisanju Associated Pressa, kompanija posebno naglašava da nijedna država ili kompanija ne može sama rešiti pitanje bezbednosti veštačke inteligencije. Umesto toga, predlaže međunarodnu saradnju vodećih tehnoloških kompanija, naučnih institucija i vlada kako bi se uspostavili zajednički standardi za razvoj najnaprednijih AI sistema.",
+  "Ova rasprava predstavlja novu fazu u razvoju veštačke inteligencije. Pre samo nekoliko godina govorilo se uglavnom o tome šta AI može da uradi. Danas se sve češće postavlja drugačije pitanje — kako obezbediti da njene sposobnosti rastu uporedo sa mehanizmima koji će omogućiti bezbednu i odgovornu primenu.",
+  "Bez obzira na to da li će predlozi kompanije Anthropic biti prihvaćeni, jedno je izvesno: debata o budućnosti veštačke inteligencije više se ne vodi samo među inženjerima. Ona postaje tema međunarodne politike, ekonomije i bezbednosti, sa mogućim posledicama koje će u narednim godinama oblikovati način na koji društvo koristi jednu od najmoćnijih tehnologija savremenog doba.",
+];
+
+export default function AnthropicAIGovernanceArticle() {
+  return (
+    <ArticleTemplate
+      path="/nasa-planeta/anthropic-upozorava-da-li-razvoj-vestacke-inteligencije-postaje-brzi-od-nase-sposobnosti-da-je-kontrolisemo"
+      sectionLabel="Naša planeta"
+      title="Anthropic upozorava: da li razvoj veštačke inteligencije postaje brži od naše sposobnosti da je kontrolišemo?"
+      dateLabel="28. jun 2026."
+      deck="Jedna od vodećih svetskih kompanija za razvoj veštačke inteligencije upozorava da bi napredak najmoćnijih AI sistema uskoro mogao da nadmaši postojeće bezbednosne mehanizme namenjene njihovoj kontroli."
+      imageSrc="/news/ai-governance-safeguards.jpg"
+      imageAlt="Minimalist editorial illustration about AI governance and safety"
+      imageCredit="Ilustracija / Novi Talas"
+      paragraphs={PARAGRAPHS}
+      backHref="/nasa-planeta"
+      backLabel="← Nazad na Našu planetu"
+    />
+  );
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -23,6 +23,17 @@ const HERO_ARTICLE = {
 
 const ARTICLES = [
   {
+    href: "/nasa-planeta/anthropic-upozorava-da-li-razvoj-vestacke-inteligencije-postaje-brzi-od-nase-sposobnosti-da-je-kontrolisemo",
+    category: "Naša planeta",
+    title:
+      "Anthropic upozorava: da li razvoj veštačke inteligencije postaje brži od naše sposobnosti da je kontrolišemo?",
+    description:
+      "Jedna od vodećih svetskih kompanija za razvoj veštačke inteligencije upozorava da bi napredak najmoćnijih AI sistema uskoro mogao da nadmaši postojeće bezbednosne mehanizme namenjene njihovoj kontroli.",
+    imageSrc: "/news/ai-governance-safeguards.jpg",
+    imageAlt:
+      "Minimalist editorial illustration about AI governance and safety",
+  },
+  {
     href: "/nasa-planeta/hiljade-vespi-preplavile-rim-povodom-80-godina-italijanske-ikone",
     category: "Naša planeta",
     title: "Hiljade Vespi preplavile Rim povodom 80 godina italijanske ikone",
@@ -74,16 +85,6 @@ const ARTICLES = [
     imageSrc: "/news/g7-supports-us-iran-deal.jpg",
     imageAlt:
       "Minimalist editorial illustration of G7 support for a US-Iran agreement, with a stylized Middle East map and summit table",
-  },
-  {
-    href: "/geopolitika/london-kampanja-protiv-dezinformacija",
-    category: "Geopolitika",
-    title: "London pokreće kampanju od 7 miliona funti protiv dezinformacija",
-    description:
-      "Gradske vlasti tvrde da koordinisane kampanje na društvenim mrežama narušavaju ugled britanske prestonice, zbog čega je pokrenut međunarodni program za promociju Londona i suzbijanje dezinformacija.",
-    imageSrc: "/news/london-disinformation-campaign.jpg",
-    imageAlt:
-      "London skyline with digital message overlays symbolizing disinformation campaigns",
   },
 ];
 

--- a/client/src/pages/NasaPlanetaIndex.tsx
+++ b/client/src/pages/NasaPlanetaIndex.tsx
@@ -19,6 +19,16 @@ type NasaPlanetaArticle = {
 
 const ARTICLES: NasaPlanetaArticle[] = [
   {
+    href: "/nasa-planeta/anthropic-upozorava-da-li-razvoj-vestacke-inteligencije-postaje-brzi-od-nase-sposobnosti-da-je-kontrolisemo",
+    img: "/news/ai-governance-safeguards.jpg",
+    alt: "Minimalist editorial illustration about AI governance and safety",
+    imageCredit: "Ilustracija / Novi Talas",
+    title:
+      "Anthropic upozorava: da li razvoj veštačke inteligencije postaje brži od naše sposobnosti da je kontrolišemo?",
+    description:
+      "Jedna od vodećih svetskih kompanija za razvoj veštačke inteligencije upozorava da bi napredak najmoćnijih AI sistema uskoro mogao da nadmaši postojeće bezbednosne mehanizme namenjene njihovoj kontroli.",
+  },
+  {
     href: "/nasa-planeta/hiljade-vespi-preplavile-rim-povodom-80-godina-italijanske-ikone",
     img: "/news/vespa-rome-80th-anniversary.jpg",
     alt: "Watercolor editorial illustration of the 80th anniversary Vespa parade through Rome",

--- a/shared/articleMeta.ts
+++ b/shared/articleMeta.ts
@@ -143,6 +143,16 @@ export function buildJsonLd(meta: {
  */
 export const articleMeta: ArticleStaticMeta[] = [
   {
+    path: "/nasa-planeta/anthropic-upozorava-da-li-razvoj-vestacke-inteligencije-postaje-brzi-od-nase-sposobnosti-da-je-kontrolisemo",
+    title:
+      "Anthropic upozorava: da li razvoj veštačke inteligencije postaje brži od naše sposobnosti da je kontrolišemo?",
+    description:
+      "Jedna od vodećih svetskih kompanija za razvoj veštačke inteligencije upozorava da bi napredak najmoćnijih AI sistema uskoro mogao da nadmaši postojeće bezbednosne mehanizme namenjene njihovoj kontroli.",
+    imageSrc: "/news/ai-governance-safeguards.jpg",
+    datePublished: "2026-06-28",
+    author: "Novi Talas",
+  },
+  {
     path: "/nasa-planeta/hiljade-vespi-preplavile-rim-povodom-80-godina-italijanske-ikone",
     title: "Hiljade Vespi preplavile Rim povodom 80 godina italijanske ikone",
     description:


### PR DESCRIPTION
### Motivation
- Publish a new article about Anthropic's AI governance warning and make it accessible in the site navigation and metadata registry.

### Description
- Add new page component `client/src/pages/AnthropicAIGovernanceArticle.tsx` that renders the article via `ArticleTemplate` with image, deck and paragraphs.
- Register the article by importing the component and adding a new `<Route>` in `client/src/App.tsx` for the article path.
- Surface the article on the homepage by inserting it into the `ARTICLES` array in `client/src/pages/Home.tsx` and in the `ARTICLES` list of `client/src/pages/NasaPlanetaIndex.tsx` for the section listing.
- Add article metadata entry to `shared/articleMeta.ts` so static HTML/OG/Twitter tags are generated for the new article.

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) which completed successfully.
- Performed a local build via `yarn build` which succeeded and included the new page bundle.
- Executed the test suite with `yarn test` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41862660cc8325b800eadc1053d2a8)