### PR TITLE
Add Geopolitika article on renewed US–Iran escalation; register route, homepage hero, and SEO

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,28 +1,49 @@
 <!doctype html>
 <html lang="sr">
-
   <head>
-    <meta name="google-site-verification" content="ub2WNnMTbqYPflHajGsmyPmMTNUvgYh_o1PNKj9nLsw" />
+    <meta
+      name="google-site-verification"
+      content="ub2WNnMTbqYPflHajGsmyPmMTNUvgYh_o1PNKj9nLsw"
+    />
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+      content="width=device-width, initial-scale=1.0, maximum-scale=1"
+    />
     <title>NOVI TALAS — Vaš prozor u svet</title>
-    <meta name="description" content="Novi Talas — nezavisni portal za geopolitiku, bezbednost i obaveštajne analize. Veritas ante omnia." />
+    <meta
+      name="description"
+      content="Novi Talas — nezavisni portal za geopolitiku, bezbednost i obaveštajne analize. Veritas ante omnia."
+    />
+    <meta name="keywords" content="" />
     <meta property="og:title" content="NOVI TALAS" />
-    <meta property="og:description" content="Nezavisni portal za geopolitiku, bezbednost i obaveštajne analize. Veritas ante omnia." />
+    <meta
+      property="og:description"
+      content="Nezavisni portal za geopolitiku, bezbednost i obaveštajne analize. Veritas ante omnia."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://novitalas.org" />
     <meta property="og:image" content="" />
     <meta property="og:site_name" content="NOVI TALAS" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="NOVI TALAS" />
-    <meta name="twitter:description" content="Nezavisni portal za geopolitiku, bezbednost i obaveštajne analize. Veritas ante omnia." />
+    <meta
+      name="twitter:description"
+      content="Nezavisni portal za geopolitiku, bezbednost i obaveštajne analize. Veritas ante omnia."
+    />
     <meta name="twitter:image" content="" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Crimson+Pro:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-    <link rel="preload" as="image" href="/hero/novitalas-hero.jpg" fetchpriority="high" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Crimson+Pro:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Source+Sans+3:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="/hero/novitalas-hero.jpg"
+      fetchpriority="high"
+    />
   </head>
 
   <body>
@@ -31,7 +52,7 @@
     <script
       defer
       src="%VITE_ANALYTICS_ENDPOINT%/umami"
-      data-website-id="%VITE_ANALYTICS_WEBSITE_ID%"></script>
+      data-website-id="%VITE_ANALYTICS_WEBSITE_ID%"
+    ></script>
   </body>
-
 </html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ import G7UsIranAgreementArticle from "./pages/G7UsIranAgreementArticle";
 import G7GeopoliticalStrategyArticle from "./pages/G7GeopoliticalStrategyArticle";
 import PraguePublicMediaProtestArticle from "./pages/PraguePublicMediaProtestArticle";
 import CrimeaDroneAttacksArticle from "./pages/CrimeaDroneAttacksArticle";
+import OdPrimirjaDoNovihUdaraSadIran from "./pages/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana";
 
 import UkrajinaCetiriGodine from "./pages/ukrajina-cetiri-godine-rata";
 import IranProtesti2026 from "./pages/iran-protesti-2026";
@@ -285,6 +286,10 @@ function Router() {
         {/* =========================
             GEOPOLITIKA
            ========================= */}
+        <Route
+          path="/geopolitika/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana"
+          component={OdPrimirjaDoNovihUdaraSadIran}
+        />
         <Route
           path="/geopolitika/mundijal-na-granici-fudbal-vize-i-politika-moci"
           component={MundijalNaGraniciFudbalVizeIPolitikaMoci}

--- a/client/src/components/ArticleTemplate.tsx
+++ b/client/src/components/ArticleTemplate.tsx
@@ -13,7 +13,12 @@ type ArticleInlineImage = {
   heightClass?: string;
 };
 
-type ArticleParagraph = string | ArticleInlineImage;
+type ArticleSectionHeading = {
+  type: "heading";
+  text: string;
+};
+
+type ArticleParagraph = string | ArticleInlineImage | ArticleSectionHeading;
 
 const EM_DASH_REPLACEMENT = ",";
 
@@ -38,7 +43,7 @@ type ArticleTemplateProps = {
   imageAlt?: string;
   imageCredit?: string;
   imageHeightClass?: string;
-  imageFirst?: boolean; 
+  imageFirst?: boolean;
   paragraphs: ArticleParagraph[];
   infoBox?: InfoBox;
   backHref: string;
@@ -85,7 +90,7 @@ export default function ArticleTemplate({
         style={{ backgroundColor: isDark ? "#111318" : "#ffffff" }}
       >
         <article className="max-w-[860px] mx-auto px-5">
-                    {/* Slika pre naslova */}
+          {/* Slika pre naslova */}
           {imageFirst && imageSrc ? (
             <div className="mb-8">
               <div
@@ -211,12 +216,22 @@ export default function ArticleTemplate({
                           ? "#cfcac0"
                           : "#b7b2aa"
                         : idx === 0
-                        ? "#222"
-                        : "#333",
+                          ? "#222"
+                          : "#333",
                     }}
                   >
                     {normalizeEmDashes(p)}
                   </p>
+                ) : p.type === "heading" ? (
+                  <h2
+                    className="mt-10 text-[26px] md:text-[32px] font-bold leading-[1.2]"
+                    style={{
+                      fontFamily: "'Playfair Display', serif",
+                      color: isDark ? "#e0ddd5" : "#111",
+                    }}
+                  >
+                    {p.text}
+                  </h2>
                 ) : (
                   <figure
                     className="mt-5 border overflow-hidden"
@@ -233,9 +248,7 @@ export default function ArticleTemplate({
                       decoding="async"
                     />
                     {p.credit ? (
-                      <figcaption
-                        className="photo-credit px-2 pb-2"
-                      >
+                      <figcaption className="photo-credit px-2 pb-2">
                         {p.credit}
                       </figcaption>
                     ) : null}

--- a/client/src/components/SeoMeta.tsx
+++ b/client/src/components/SeoMeta.tsx
@@ -44,13 +44,9 @@ export default function SeoMeta({
   imageSrc,
 }: SeoMetaProps) {
   useEffect(() => {
-    const setMeta = (
-      attrName: string,
-      attrValue: string,
-      content: string,
-    ) => {
+    const setMeta = (attrName: string, attrValue: string, content: string) => {
       let el = document.querySelector(
-        `meta[${attrName}="${attrValue}"]`,
+        `meta[${attrName}="${attrValue}"]`
       ) as HTMLMetaElement | null;
       if (!el) {
         el = document.createElement("meta");
@@ -89,13 +85,20 @@ export default function SeoMeta({
     if (explicit) {
       document.title = explicit.title;
       setMeta("name", "description", explicit.description);
+      if (explicit.keywords) {
+        setMeta("name", "keywords", explicit.keywords);
+      }
       setMeta("property", "og:type", "article");
       setMeta("property", "og:title", explicit.ogTitle);
       setMeta("property", "og:description", explicit.ogDescription);
       setMeta("property", "og:url", explicit.ogUrl);
       setMeta("property", "og:image", explicit.ogImage);
       if (explicit.datePublished) {
-        setMeta("property", "og:article:published_time", `${explicit.datePublished}T00:00:00+01:00`);
+        setMeta(
+          "property",
+          "og:article:published_time",
+          `${explicit.datePublished}T00:00:00+01:00`
+        );
       }
       setMeta("name", "twitter:title", explicit.twitterTitle);
       setMeta("name", "twitter:description", explicit.twitterDescription);
@@ -109,11 +112,11 @@ export default function SeoMeta({
           ogImage: explicit.ogImage,
           datePublished: explicit.datePublished,
           author: explicit.author,
-        }),
+        })
       );
     } else {
       // ── Priority 2: articleMeta registry entry ───────────────────────────
-      const registered = articleMeta.find((m) => m.path === path);
+      const registered = articleMeta.find(m => m.path === path);
       if (registered) {
         const ogImage = buildOgImageUrl(registered.imageSrc);
         const ogUrl = `${SITE_BASE}${registered.path}`;
@@ -125,7 +128,11 @@ export default function SeoMeta({
         setMeta("property", "og:url", ogUrl);
         setMeta("property", "og:image", ogImage);
         if (registered.datePublished) {
-          setMeta("property", "og:article:published_time", `${registered.datePublished}T00:00:00+01:00`);
+          setMeta(
+            "property",
+            "og:article:published_time",
+            `${registered.datePublished}T00:00:00+01:00`
+          );
         }
         setMeta("name", "twitter:title", registered.title);
         setMeta("name", "twitter:description", registered.description);
@@ -139,7 +146,7 @@ export default function SeoMeta({
             ogImage,
             datePublished: registered.datePublished,
             author: registered.author,
-          }),
+          })
         );
       } else if (title) {
         // ── Priority 3: direct props (inline fallback) ────────────────────
@@ -166,7 +173,7 @@ export default function SeoMeta({
             description: description ?? "",
             ogUrl,
             ogImage,
-          }),
+          })
         );
       }
     }

--- a/client/src/pages/GeopolitikaIndex.tsx
+++ b/client/src/pages/GeopolitikaIndex.tsx
@@ -18,6 +18,15 @@ type Article = {
 
 const ARTICLES: Article[] = [
   {
+    href: "/geopolitika/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana",
+    title:
+      "Od primirja do novih udara: kako je ponovo eskalirao sukob SAD i Irana",
+    description:
+      "Nekoliko dana nakon novih pregovora i nagoveštaja smirivanja tenzija, Bliski istok ponovo se našao na ivici ozbiljne eskalacije, dok Ormuski moreuz postaje jedna od ključnih tačaka globalne nestabilnosti.",
+    imageSrc: "/news/hormuz-chokepoint.jpg",
+    imageAlt: "Ormuski moreuz, strateški pomorski prolaz između Irana i Omana",
+  },
+  {
     href: "/geopolitika/krim-u-vanrednoj-situaciji-nakon-masovnog-napada-dronovima",
     title:
       "Krim u vanrednoj situaciji nakon masovnog napada dronovima: rat ulazi u novu fazu",

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,14 +10,14 @@ import Footer from "@/components/Footer";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const HERO_ARTICLE = {
-  href: "/nasa-planeta/pol-makartni-sa-rolingstonsima-na-novom-albumu-koji-izlazi-10-jula",
-  category: "Naša planeta",
-  title: "Pol Makartni sa Rolingstonsima na novom albumu koji izlazi 10. jula",
+  href: "/geopolitika/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana",
+  category: "Geopolitika",
+  title:
+    "Od primirja do novih udara: kako je ponovo eskalirao sukob SAD i Irana",
   description:
-    "Više od šest decenija nakon što su Bitlsi i Rolingstonsi obeležili jednu od najuzbudljivijih epoha u istoriji popularne muzike, Pol Makartni ponovo gostuje na novom studijskom albumu slavnog britanskog benda.",
-  imageSrc: "/news/paul-mccartney-rolling-stones.jpg",
-  imageAlt:
-    "Ilustracija Pola Makartnija i Mika Džegera povodom nove saradnje na albumu Foreign Tongues.",
+    "Nekoliko dana nakon novih pregovora i nagoveštaja smirivanja tenzija, Bliski istok ponovo se našao na ivici ozbiljne eskalacije, dok Ormuski moreuz postaje jedna od ključnih tačaka globalne nestabilnosti.",
+  imageSrc: "/news/hormuz-chokepoint.jpg",
+  imageAlt: "Ormuski moreuz, strateški pomorski prolaz između Irana i Omana",
 };
 
 const ARTICLES = [

--- a/client/src/pages/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana.tsx
+++ b/client/src/pages/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana.tsx
@@ -1,0 +1,41 @@
+import ArticleTemplate from "@/components/ArticleTemplate";
+
+const PATH =
+  "/geopolitika/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana";
+const IMAGE_SRC = "/news/hormuz-chokepoint.jpg";
+
+const PARAGRAPHS = [
+  "Nekoliko dana pošto su obnovljeni diplomatski kontakti između Vašingtona i Teherana podigli očekivanja da bi krhko primirje moglo prerasti u stabilniji aranžman, bezbednosna slika Persijskog zaliva ponovo se naglo pogoršala. Razgovori su ostavili utisak da obe strane traže način da zaustave spiralu odmazde, ali nisu otklonili sporove o regionalnom vojnom prisustvu, sankcijama i uslovima pomorske bezbednosti.",
+  "Prvi znak da politički kanal nije dovoljan stigao je sa mora. Novi incidenti sa trgovačkim brodovima i upozorenja posadama u prilazima Ormuskom moreuzu podigli su cenu osiguranja i usporili kretanje tankera. U prostoru u kome se civilni promet, ratni brodovi i obalska odbrana nalaze na malim udaljenostima, i nejasan signal lako prerasta u bezbednosni događaj sa globalnim posledicama.",
+  "Vašington je zatim obnovio vojne udare na ciljeve koje opisuje kao povezane sa iranskim kapacitetima za nadzor, bespilotne sisteme i ugrožavanje pomorskih ruta. Američka poruka bila je da operacije imaju ograničen cilj, zaštitu snaga i slobode plovidbe, a ne otvaranje novog fronta. Ipak, svaki udar u ovakvom sukobu istovremeno je i vojna akcija i politički signal, na koji Teheran teško može da odgovori ćutanjem.",
+  "Iran je uzvratio upozorenjima da bezbednost plovidbe ne može biti odvojena od njegove bezbednosti i od prisustva stranih snaga u Zalivu. Zvaničnici u Teheranu ostavili su otvorenom mogućnost pojačane kontrole pomorskih prilaza, dok su regionalne države pozvale na uzdržanost i očuvanje komercijalnih koridora. Njihov interes je neposredan: zemlje Zaliva zavise od predvidivog izvoza energije, a susedi Irana od toga da lokalni sukob ne pređe njihove granice.",
+  "Reakcija tržišta pokazala je koliko je ta veza neposredna. Dovoljna je bila mogućnost poremećaja da se ponovo otvore pitanja o raspoloživim zalihama, alternativnim rutama i ceni transporta. Za velike uvoznike energije u Aziji, ali i za evropske privrede koje već računaju na stabilnije energetske tokove, Ormus nije udaljena geografska tačka, već prolaz kroz koji se meri cena svakog novog rizika.",
+  "Moreuz je zato više od uskog morskog pojasa između Irana i Omana. Kroz njega prolazi značajan deo svetskog pomorskog izvoza nafte i tečnog prirodnog gasa iz Persijskog zaliva. Njegova širina, blizina obale i ograničen broj bezbednih plovnih koridora daju svakoj strani sposobnost da izazove zastoj, čak i bez formalne blokade. Upravo ta kombinacija geografije i energetike čini ga jednim od najosetljivijih mesta savremene geopolitike.",
+  {
+    type: "heading" as const,
+    text: "Energetska bezbednost kao granica eskalacije",
+  },
+  "Ni Vašington ni Teheran trenutno nemaju jasan interes za puni regionalni rat. Sjedinjene Države nastoje da održe kredibilitet odvraćanja i zaštite saveznike, ali znaju da bi širok sukob iscrpeo vojne kapacitete i uvukao u krizu države koje pokušavaju da ostanu po strani. Iran, sa svoje strane, želi da pokaže da na pritisak može odgovoriti, ali bi otvoreni rat ugrozio njegovu infrastrukturu, ekonomiju i unutrašnju stabilnost.",
+  "To ne znači da je deeskalacija izvesna. Naprotiv, ograničeni ciljevi obe strane stvaraju opasnu zonu u kojoj svaka želi da demonstrira odlučnost bez prelaska praga rata. U takvom rasporedu pogrešna procena komandanta na moru, incident sa tankerom ili napad čije posledice nisu odmah jasne mogu pokrenuti lanac odgovora koji diplomatski kanali više ne bi mogli lako da zaustave.",
+  "Energetska bezbednost zato postaje središnje pitanje, a ne sporedna ekonomska posledica krize. Ormuski moreuz je jedan od glavnih svetskih naftnih uskih grla: prekid saobraćaja ne bi pogodio samo proizvođače iz Zaliva, već bi brzo promenio računicu rafinerija, brodarskih kompanija, osiguravača i vlada koje upravljaju strateškim rezervama. Alternative postoje, ali nijedna ne može brzo i u potpunosti zameniti tokove koji prolaze kroz moreuz.",
+  "Za Evropu bi produžena nestabilnost značila skuplju energiju, veće troškove prevoza i dodatni pritisak na industriju i potrošačke cene. Globalna trgovina bi osetila posledice kroz premije osiguranja, promenjene rute i kašnjenja isporuka, dok bi rast cene nafte dodatno otežao rad centralnih banaka. Najveći rizik nije samo zatvaranje prolaza, već trajna neizvesnost, stanje u kome tržišta počinju da uračunavaju krizu kao novu normalnost.",
+  "Zato se budućnost ovog sukoba neće odlučivati samo u pregovaračkim salama ili na vojnim kartama. Ona će se meriti sposobnošću obe strane da kontrolišu događaje u uskom pomorskom prostoru u kome lokalni incident gotovo automatski dobija međunarodnu cenu. Ormuski moreuz ostaje mesto na kome se susreću regionalna bezbednost, globalna energija i granice moći velikih država.",
+];
+
+export default function OdPrimirjaDoNovihUdaraSadIran() {
+  return (
+    <ArticleTemplate
+      path={PATH}
+      sectionLabel="GEOPOLITIKA"
+      title="Od primirja do novih udara: kako je ponovo eskalirao sukob SAD i Irana"
+      dateLabel="16. JUL 2026."
+      deck="Nekoliko dana nakon novih pregovora i nagoveštaja smirivanja tenzija, Bliski istok ponovo se našao na ivici ozbiljne eskalacije, dok Ormuski moreuz postaje jedna od ključnih tačaka globalne nestabilnosti."
+      imageSrc={IMAGE_SRC}
+      imageAlt="Ormuski moreuz, strateški pomorski prolaz između Irana i Omana"
+      imageFirst={true}
+      paragraphs={PARAGRAPHS}
+      backHref="/geopolitika"
+      backLabel="← Nazad na Geopolitiku"
+    />
+  );
+}

--- a/scripts/generate-seo-pages.ts
+++ b/scripts/generate-seo-pages.ts
@@ -75,52 +75,56 @@ function escapeHtml(str: string): string {
 function injectSEO(
   html: string,
   route: string,
-  seo?: ReturnType<typeof buildSEOFromArticleMeta>,
+  seo?: ReturnType<typeof buildSEOFromArticleMeta>
 ): string {
   const resolvedSeo = seo ?? seoData[route];
   if (!resolvedSeo) return html;
 
   let result = html
-    .replace(/<title>.*?<\/title>/, `<title>${escapeHtml(resolvedSeo.title)}</title>`)
+    .replace(
+      /<title>.*?<\/title>/,
+      `<title>${escapeHtml(resolvedSeo.title)}</title>`
+    )
     .replace(
       /(<meta\s+name="description"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(resolvedSeo.description)}$2`,
+      `$1${escapeHtml(resolvedSeo.description)}$2`
     )
     .replace(
-      /(<meta\s+property="og:type"\s+content=")[^"]*(")/,
-      `$1article$2`,
+      /(<meta\s+name="keywords"\s+content=")[^"]*(")/,
+      `$1${escapeHtml(resolvedSeo.keywords ?? "")}$2`
     )
+    .replace(/(<meta\s+property="og:type"\s+content=")[^"]*(")/, `$1article$2`)
     .replace(
       /(<meta\s+property="og:title"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(resolvedSeo.ogTitle)}$2`,
+      `$1${escapeHtml(resolvedSeo.ogTitle)}$2`
     )
     .replace(
       /(<meta\s+property="og:description"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(resolvedSeo.ogDescription)}$2`,
+      `$1${escapeHtml(resolvedSeo.ogDescription)}$2`
     )
     .replace(
       /(<meta\s+property="og:url"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(resolvedSeo.ogUrl)}$2`,
+      `$1${escapeHtml(resolvedSeo.ogUrl)}$2`
     )
     .replace(
       /(<meta\s+property="og:image"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(resolvedSeo.ogImage)}$2`,
+      `$1${escapeHtml(resolvedSeo.ogImage)}$2`
     )
     .replace(
       /(<meta\s+name="twitter:card"\s+content=")[^"]*(")/,
-      `$1summary_large_image$2`,
+      `$1summary_large_image$2`
     )
     .replace(
       /(<meta\s+name="twitter:title"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(resolvedSeo.twitterTitle)}$2`,
+      `$1${escapeHtml(resolvedSeo.twitterTitle)}$2`
     )
     .replace(
       /(<meta\s+name="twitter:description"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(resolvedSeo.twitterDescription)}$2`,
+      `$1${escapeHtml(resolvedSeo.twitterDescription)}$2`
     )
     .replace(
       /(<meta\s+name="twitter:image"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(resolvedSeo.twitterImage)}$2`,
+      `$1${escapeHtml(resolvedSeo.twitterImage)}$2`
     );
 
   // Derive the MIME type from the image URL's file extension.
@@ -147,7 +151,7 @@ function injectSEO(
 
   result = result.replace(
     /(<meta\s+property="og:image"[^>]*>)/,
-    `$1\n${extraOgImageTags}`,
+    `$1\n${extraOgImageTags}`
   );
 
   // Add og:article:published_time when a publish date is available.
@@ -186,7 +190,7 @@ function injectSEO(
  */
 function generateSitemap(
   distPublicPath: string,
-  mergedSeoData: Record<string, ReturnType<typeof buildSEOFromArticleMeta>>,
+  mergedSeoData: Record<string, ReturnType<typeof buildSEOFromArticleMeta>>
 ): void {
   const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
 
@@ -202,18 +206,16 @@ function generateSitemap(
         `    <changefreq>${entry.changefreq}</changefreq>`,
         `    <priority>${entry.priority}</priority>`,
         `  </url>`,
-      ].join("\n"),
+      ].join("\n")
     );
   }
 
   // 2. Individual article pages (sorted by datePublished descending, then path)
-  const articleEntries = Object.entries(mergedSeoData).sort(
-    ([, a], [, b]) => {
-      const dateA = a.datePublished ?? "0000-00-00";
-      const dateB = b.datePublished ?? "0000-00-00";
-      return dateB.localeCompare(dateA);
-    },
-  );
+  const articleEntries = Object.entries(mergedSeoData).sort(([, a], [, b]) => {
+    const dateA = a.datePublished ?? "0000-00-00";
+    const dateB = b.datePublished ?? "0000-00-00";
+    return dateB.localeCompare(dateA);
+  });
 
   for (const [route, seo] of articleEntries) {
     const lastmod = seo.datePublished ?? today;
@@ -225,7 +227,7 @@ function generateSitemap(
         `    <changefreq>monthly</changefreq>`,
         `    <priority>0.7</priority>`,
         `  </url>`,
-      ].join("\n"),
+      ].join("\n")
     );
   }
 
@@ -239,7 +241,9 @@ function generateSitemap(
 
   const sitemapPath = path.join(distPublicPath, "sitemap.xml");
   fs.writeFileSync(sitemapPath, xml, "utf-8");
-  console.log(`\n✅ Sitemap written to dist/public/sitemap.xml (${articleEntries.length} articles + ${STATIC_SITEMAP_ENTRIES.length} static pages)`);
+  console.log(
+    `\n✅ Sitemap written to dist/public/sitemap.xml (${articleEntries.length} articles + ${STATIC_SITEMAP_ENTRIES.length} static pages)`
+  );
 }
 
 async function main() {
@@ -248,7 +252,7 @@ async function main() {
 
   if (!fs.existsSync(indexHtmlPath)) {
     console.error(
-      "ERROR: dist/public/index.html not found. Run `vite build` first.",
+      "ERROR: dist/public/index.html not found. Run `vite build` first."
     );
     process.exit(1);
   }
@@ -298,7 +302,7 @@ async function main() {
   generateSitemap(distPublicPath, mergedSeoData);
 }
 
-main().catch((err) => {
+main().catch(err => {
   console.error("generate-seo-pages failed:", err);
   process.exit(1);
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,7 +14,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Build a merged lookup: seo.ts (explicit) takes priority over articleMeta.
-const mergedSeoLookup: Record<string, ReturnType<typeof buildSEOFromArticleMeta>> = {};
+const mergedSeoLookup: Record<
+  string,
+  ReturnType<typeof buildSEOFromArticleMeta>
+> = {};
 for (const meta of articleMeta) {
   mergedSeoLookup[meta.path] = buildSEOFromArticleMeta(meta);
 }
@@ -54,43 +57,44 @@ function injectSEO(html: string, route: string): string {
     .replace(/<title>.*?<\/title>/, `<title>${escapeHtml(seo.title)}</title>`)
     .replace(
       /(<meta\s+name="description"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(seo.description)}$2`,
+      `$1${escapeHtml(seo.description)}$2`
     )
     .replace(
-      /(<meta\s+property="og:type"\s+content=")[^"]*(")/,
-      `$1article$2`,
+      /(<meta\s+name="keywords"\s+content=")[^"]*(")/,
+      `$1${escapeHtml(seo.keywords ?? "")}$2`
     )
+    .replace(/(<meta\s+property="og:type"\s+content=")[^"]*(")/, `$1article$2`)
     .replace(
       /(<meta\s+property="og:title"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(seo.ogTitle)}$2`,
+      `$1${escapeHtml(seo.ogTitle)}$2`
     )
     .replace(
       /(<meta\s+property="og:description"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(seo.ogDescription)}$2`,
+      `$1${escapeHtml(seo.ogDescription)}$2`
     )
     .replace(
       /(<meta\s+property="og:url"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(seo.ogUrl)}$2`,
+      `$1${escapeHtml(seo.ogUrl)}$2`
     )
     .replace(
       /(<meta\s+property="og:image"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(seo.ogImage)}$2`,
+      `$1${escapeHtml(seo.ogImage)}$2`
     )
     .replace(
       /(<meta\s+name="twitter:card"\s+content=")[^"]*(")/,
-      `$1summary_large_image$2`,
+      `$1summary_large_image$2`
     )
     .replace(
       /(<meta\s+name="twitter:title"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(seo.twitterTitle)}$2`,
+      `$1${escapeHtml(seo.twitterTitle)}$2`
     )
     .replace(
       /(<meta\s+name="twitter:description"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(seo.twitterDescription)}$2`,
+      `$1${escapeHtml(seo.twitterDescription)}$2`
     )
     .replace(
       /(<meta\s+name="twitter:image"\s+content=")[^"]*(")/,
-      `$1${escapeHtml(seo.twitterImage)}$2`,
+      `$1${escapeHtml(seo.twitterImage)}$2`
     );
 
   // Derive MIME type from the image URL's file extension.
@@ -114,7 +118,7 @@ function injectSEO(html: string, route: string): string {
 
   result = result.replace(
     /(<meta\s+property="og:image"[^>]*>)/,
-    `$1\n${extraOgImageTags}`,
+    `$1\n${extraOgImageTags}`
   );
 
   // Add og:article:published_time when a publish date is available.

--- a/shared/articleMeta.ts
+++ b/shared/articleMeta.ts
@@ -38,6 +38,8 @@ export interface ArticleStaticMeta {
   datePublished?: string;
   /** Article author name. Defaults to "Novi Talas" if omitted. */
   author?: string;
+  /** Comma-separated article keywords for search engines that use the tag. */
+  keywords?: string;
 }
 
 /** Convert a relative image path to an absolute URL suitable for og:image. */
@@ -63,6 +65,7 @@ export function buildSEOFromArticleMeta(meta: ArticleStaticMeta) {
     twitterImage: ogImage,
     datePublished: meta.datePublished,
     author: meta.author,
+    keywords: meta.keywords,
   };
 }
 

--- a/shared/seo.ts
+++ b/shared/seo.ts
@@ -12,9 +12,34 @@ export interface SEOData {
   datePublished?: string;
   /** Author display name. Defaults to "Novi Talas" when omitted. */
   author?: string;
+  /** Comma-separated article keywords for search engines that use the tag. */
+  keywords?: string;
 }
 
 export const seoData: Record<string, SEOData> = {
+  "/geopolitika/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana":
+    {
+      title:
+        "Od primirja do novih udara: kako je ponovo eskalirao sukob SAD i Irana | Novi Talas",
+      description:
+        "Posle novih pregovora između Vašingtona i Teherana, situacija na Bliskom istoku ponovo se zaoštrava. Zašto je Ormuski moreuz ponovo u centru svetske geopolitike?",
+      ogTitle:
+        "Od primirja do novih udara: kako je ponovo eskalirao sukob SAD i Irana",
+      ogDescription:
+        "Posle novih pregovora između Vašingtona i Teherana, situacija na Bliskom istoku ponovo se zaoštrava. Zašto je Ormuski moreuz ponovo u centru svetske geopolitike?",
+      ogUrl:
+        "https://novitalas.org/geopolitika/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana",
+      ogImage: "https://novitalas.org/news/hormuz-chokepoint.jpg",
+      twitterTitle:
+        "Od primirja do novih udara: kako je ponovo eskalirao sukob SAD i Irana",
+      twitterDescription:
+        "Posle novih pregovora između Vašingtona i Teherana, situacija na Bliskom istoku ponovo se zaoštrava. Zašto je Ormuski moreuz ponovo u centru svetske geopolitike?",
+      twitterImage: "https://novitalas.org/news/hormuz-chokepoint.jpg",
+      datePublished: "2026-07-16",
+      author: "Novi Talas",
+      keywords:
+        "United States, Iran, Strait of Hormuz, Persian Gulf, Middle East, oil, geopolitics, SAD, Iran, Ormuski moreuz, Bliski istok, nafta, geopolitika, Novi Talas",
+    },
   "/geopolitika/60-dana-bliski-istok-sad-iran-dogovor": {
     title:
       "60 dana za Bliski istok: iza pregovora SAD i Irana krije se mnogo veći dogovor | Novi Talas",
@@ -198,25 +223,26 @@ export const seoData: Record<string, SEOData> = {
     author: "Novi Talas",
   },
 
-  "/srbija/senke-nad-ekranom-tiho-preuzimanje-ili-kontrolisano-gasenje-istine": {
-    title:
-      "SENKE NAD EKRANOM: Tiho preuzimanje ili kontrolisano gašenje istine — Novi Talas",
-    description:
-      "Proces pritiska na nezavisne medije retko je otvoren i nagao. Mnogo češće odvija se postepeno, kroz smene, promene uređivačke politike i sužavanje prostora javne reči. Slučaj N1 otvara pitanje granica takvog procesa u savremenom društvu.",
-    ogTitle:
-      "SENKE NAD EKRANOM: Tiho preuzimanje ili kontrolisano gašenje istine",
-    ogDescription:
-      "Proces pritiska na nezavisne medije retko je otvoren i nagao. Mnogo češće odvija se postepeno, kroz smene, promene uređivačke politike i sužavanje prostora javne reči. Slučaj N1 otvara pitanje granica takvog procesa u savremenom društvu.",
-    ogUrl:
-      "https://novitalas.org/srbija/senke-nad-ekranom-tiho-preuzimanje-ili-kontrolisano-gasenje-istine",
-    ogImage: "https://novitalas.org/news/iscezavanje-N1.jpg",
-    twitterTitle:
-      "SENKE NAD EKRANOM: Tiho preuzimanje ili kontrolisano gašenje istine",
-    twitterDescription:
-      "Proces pritiska na nezavisne medije retko je otvoren i nagao. Mnogo češće odvija se postepeno, kroz smene, promene uređivačke politike i sužavanje prostora javne reči.",
-    twitterImage: "https://novitalas.org/news/iscezavanje-N1.jpg",
-    datePublished: "2026-04-11",
-  },
+  "/srbija/senke-nad-ekranom-tiho-preuzimanje-ili-kontrolisano-gasenje-istine":
+    {
+      title:
+        "SENKE NAD EKRANOM: Tiho preuzimanje ili kontrolisano gašenje istine — Novi Talas",
+      description:
+        "Proces pritiska na nezavisne medije retko je otvoren i nagao. Mnogo češće odvija se postepeno, kroz smene, promene uređivačke politike i sužavanje prostora javne reči. Slučaj N1 otvara pitanje granica takvog procesa u savremenom društvu.",
+      ogTitle:
+        "SENKE NAD EKRANOM: Tiho preuzimanje ili kontrolisano gašenje istine",
+      ogDescription:
+        "Proces pritiska na nezavisne medije retko je otvoren i nagao. Mnogo češće odvija se postepeno, kroz smene, promene uređivačke politike i sužavanje prostora javne reči. Slučaj N1 otvara pitanje granica takvog procesa u savremenom društvu.",
+      ogUrl:
+        "https://novitalas.org/srbija/senke-nad-ekranom-tiho-preuzimanje-ili-kontrolisano-gasenje-istine",
+      ogImage: "https://novitalas.org/news/iscezavanje-N1.jpg",
+      twitterTitle:
+        "SENKE NAD EKRANOM: Tiho preuzimanje ili kontrolisano gašenje istine",
+      twitterDescription:
+        "Proces pritiska na nezavisne medije retko je otvoren i nagao. Mnogo češće odvija se postepeno, kroz smene, promene uređivačke politike i sužavanje prostora javne reči.",
+      twitterImage: "https://novitalas.org/news/iscezavanje-N1.jpg",
+      datePublished: "2026-04-11",
+    },
 
   "/geopolitika/iran": {
     title:
@@ -371,11 +397,9 @@ export const seoData: Record<string, SEOData> = {
       "Velike sile i kriza u Iranu: oprezna ravnoteža Moskve i Pekinga — Novi Talas",
     description:
       "Između podrške Teheranu i izbegavanja velikog rata. Rusija i Kina razvile su bliske odnose sa Iranom, ali njihove reakcije na aktuelnu krizu pokazuju znatno oprezniji pristup.",
-    ogTitle:
-      "Velike sile i kriza u Iranu: oprezna ravnoteža Moskve i Pekinga",
+    ogTitle: "Velike sile i kriza u Iranu: oprezna ravnoteža Moskve i Pekinga",
     ogDescription: "Između podrške Teheranu i izbegavanja velikog rata.",
-    ogUrl:
-      "https://novitalas.org/geopolitika/velike-sile-i-kriza-u-iranu",
+    ogUrl: "https://novitalas.org/geopolitika/velike-sile-i-kriza-u-iranu",
     ogImage: "https://novitalas.org/og/velike-sile-i-kriza-u-iranu.jpg",
     twitterTitle:
       "Velike sile i kriza u Iranu: oprezna ravnoteža Moskve i Pekinga",
@@ -428,8 +452,7 @@ export const seoData: Record<string, SEOData> = {
       "Rat senki: povratak obaveštajnih službi u središte geopolitike — Novi Talas",
     description:
       "Analiza globalnog povratka tajnih službi na poziciju ključnog instrumenta geopolitike u novom multipolarnom svetu.",
-    ogTitle:
-      "Rat senki: povratak obaveštajnih službi u središte geopolitike",
+    ogTitle: "Rat senki: povratak obaveštajnih službi u središte geopolitike",
     ogDescription:
       "Analiza globalnog povratka tajnih službi na poziciju ključnog instrumenta geopolitike u novom multipolarnom svetu.",
     ogUrl: "https://novitalas.org/obavestajni-izvori/rat-senki",
@@ -530,8 +553,7 @@ export const seoData: Record<string, SEOData> = {
       "Najveća ALMA mapa ikad: otkriveno skriveno jezgro Mlečnog puta — Novi Talas",
     description:
       "Radio-teleskop ALMA napravio je najtačniju mapu Centralne molekularne zone Mlečnog puta, otkrivajući njegovo skriveno jezgro.",
-    ogTitle:
-      "Najveća ALMA mapa ikad: otkriveno skriveno jezgro Mlečnog puta",
+    ogTitle: "Najveća ALMA mapa ikad: otkriveno skriveno jezgro Mlečnog puta",
     ogDescription:
       "Radio-teleskop ALMA napravio je najtačniju mapu Centralne molekularne zone Mlečnog puta, otkrivajući njegovo skriveno jezgro.",
     ogUrl: "https://novitalas.org/nasa-planeta/alma-skriveno-jezgro",
@@ -565,18 +587,15 @@ export const seoData: Record<string, SEOData> = {
   },
 
   "/nasa-planeta/kubrick": {
-    title:
-      "Stenli Kjubrik i tajna filma koji ne stari — Novi Talas",
+    title: "Stenli Kjubrik i tajna filma koji ne stari — Novi Talas",
     description:
       "Dok se svet ponovo okreće ceremoniji Oskara, jedan reditelj i dalje stoji izvan logike nagrada i podseća nas da film može biti umetnost mišljenja.",
-    ogTitle:
-      "Stenli Kjubrik i tajna filma koji ne stari",
+    ogTitle: "Stenli Kjubrik i tajna filma koji ne stari",
     ogDescription:
       "Dok se svet ponovo okreće ceremoniji Oskara, jedan reditelj i dalje stoji izvan logike nagrada i podseća nas da film može biti umetnost mišljenja.",
     ogUrl: "https://novitalas.org/nasa-planeta/kubrick",
     ogImage: "https://novitalas.org/kubrick.jpg",
-    twitterTitle:
-      "Stenli Kjubrik i tajna filma koji ne stari",
+    twitterTitle: "Stenli Kjubrik i tajna filma koji ne stari",
     twitterDescription:
       "Dok se svet ponovo okreće ceremoniji Oskara, jedan reditelj i dalje stoji izvan logike nagrada i podseća nas da film može biti umetnost mišljenja.",
     twitterImage: "https://novitalas.org/kubrick.jpg",
@@ -584,18 +603,15 @@ export const seoData: Record<string, SEOData> = {
   },
 
   "/nasa-planeta/ai-vest-svest": {
-    title:
-      "Da li je veštačka inteligencija već svesna? — Novi Talas",
+    title: "Da li je veštačka inteligencija već svesna? — Novi Talas",
     description:
       "Direktor kompanije Anthropic izjavio je da naučnici sve ozbiljnije razmatraju mogućnost da napredni AI sistemi razviju neku vrstu svesti.",
-    ogTitle:
-      "Da li je veštačka inteligencija već svesna?",
+    ogTitle: "Da li je veštačka inteligencija već svesna?",
     ogDescription:
       "Direktor kompanije Anthropic izjavio je da naučnici sve ozbiljnije razmatraju mogućnost da napredni AI sistemi razviju neku vrstu svesti.",
     ogUrl: "https://novitalas.org/nasa-planeta/ai-vest-svest",
     ogImage: "https://novitalas.org/ai-supercomputer-data-center.jpg",
-    twitterTitle:
-      "Da li je veštačka inteligencija već svesna?",
+    twitterTitle: "Da li je veštačka inteligencija već svesna?",
     twitterDescription:
       "Direktor kompanije Anthropic izjavio je da naučnici sve ozbiljnije razmatraju mogućnost da napredni AI sistemi razviju neku vrstu svesti.",
     twitterImage: "https://novitalas.org/ai-supercomputer-data-center.jpg",
@@ -607,8 +623,7 @@ export const seoData: Record<string, SEOData> = {
       "Kina odobrila prvi moždani implantat za komercijalnu upotrebu — Novi Talas",
     description:
       "Kineske vlasti odobrile su prvi moždani implantat namenjen komercijalnoj upotrebi, čime je napravljen značajan korak u razvoju tehnologije brain-computer interface.",
-    ogTitle:
-      "Kina odobrila prvi moždani implantat za komercijalnu upotrebu",
+    ogTitle: "Kina odobrila prvi moždani implantat za komercijalnu upotrebu",
     ogDescription:
       "Kineske vlasti odobrile su prvi moždani implantat namenjen komercijalnoj upotrebi, čime je napravljen značajan korak u razvoju tehnologije brain-computer interface.",
     ogUrl: "https://novitalas.org/nasa-planeta/kina-mozgani-implantat",
@@ -626,14 +641,12 @@ export const seoData: Record<string, SEOData> = {
       "IEA pokreće najveće oslobađanje naftnih rezervi u istoriji — Novi Talas",
     description:
       "Države članice Međunarodne agencije za energiju puštaju 400 miliona barela nafte iz strateških rezervi kako bi ublažile globalni energetski šok izazvan krizom u Persijskom zalivu.",
-    ogTitle:
-      "IEA pokreće najveće oslobađanje naftnih rezervi u istoriji",
+    ogTitle: "IEA pokreće najveće oslobađanje naftnih rezervi u istoriji",
     ogDescription:
       "Države članice Međunarodne agencije za energiju puštaju 400 miliona barela nafte iz strateških rezervi kako bi ublažile globalni energetski šok.",
     ogUrl: "https://novitalas.org/geopolitika/rezerve-nafte",
     ogImage: "https://novitalas.org/rezerve-nafte.jpg",
-    twitterTitle:
-      "IEA pokreće najveće oslobađanje naftnih rezervi u istoriji",
+    twitterTitle: "IEA pokreće najveće oslobađanje naftnih rezervi u istoriji",
     twitterDescription:
       "Države članice Međunarodne agencije za energiju puštaju 400 miliona barela nafte iz strateških rezervi kako bi ublažile globalni energetski šok.",
     twitterImage: "https://novitalas.org/rezerve-nafte.jpg",
@@ -679,18 +692,15 @@ export const seoData: Record<string, SEOData> = {
   },
 
   "/nasa-planeta/ko-je-dobio-oskara": {
-    title:
-      "Ko je dobio Oskara? — Novi Talas",
+    title: "Ko je dobio Oskara? — Novi Talas",
     description:
       "Na 98. dodeli nagrada Američke filmske akademije najveći trijumf ostvario je film One Battle After Another. Dok svet tone u ratove, Oskar nastavlja da blista.",
-    ogTitle:
-      "Ko je dobio Oskara?",
+    ogTitle: "Ko je dobio Oskara?",
     ogDescription:
       "Dok svet tone u ratove, razaranja i očigledan pad civilizacijskih normi, ceremonija Oskara nastavlja da blista, gotovo ravnodušna prema vremenu koje izgleda poraženo.",
     ogUrl: "https://novitalas.org/nasa-planeta/ko-je-dobio-oskara",
     ogImage: "https://novitalas.org/news/oscar-world.jpg",
-    twitterTitle:
-      "Ko je dobio Oskara?",
+    twitterTitle: "Ko je dobio Oskara?",
     twitterDescription:
       "Dok svet tone u ratove, razaranja i očigledan pad civilizacijskih normi, ceremonija Oskara nastavlja da blista, gotovo ravnodušna prema vremenu koje izgleda poraženo.",
     twitterImage: "https://novitalas.org/news/oscar-world.jpg",
@@ -703,8 +713,7 @@ export const seoData: Record<string, SEOData> = {
         "CIA pokrenula kampanju za regrutovanje kineskih vojnih oficira — Novi Talas",
       description:
         "Američka CIA pokrenula javnu kampanju usmerenu ka potencijalnim izvorima unutar kineske vojske, objavivši video na kineskom jeziku koji cilja nezadovoljne oficire.",
-      ogTitle:
-        "CIA pokrenula kampanju za regrutovanje kineskih vojnih oficira",
+      ogTitle: "CIA pokrenula kampanju za regrutovanje kineskih vojnih oficira",
       ogDescription:
         "Američka CIA pokrenula javnu kampanju usmerenu ka potencijalnim izvorima unutar kineske vojske, objavivši video na kineskom jeziku koji cilja nezadovoljne oficire.",
       ogUrl:
@@ -746,7 +755,8 @@ export const seoData: Record<string, SEOData> = {
       "Nepravilnosti na izborima: zakon predviđa krivičnu odgovornost za manipulacije",
     ogDescription:
       "Prijavljene nepravilnosti tokom izbora u Srbiji otvaraju pitanje krivične odgovornosti za manipulacije i zloupotrebe izbornog procesa.",
-    ogUrl: "https://novitalas.org/srbija/izbori-nepravilnosti-krivicna-odgovornost",
+    ogUrl:
+      "https://novitalas.org/srbija/izbori-nepravilnosti-krivicna-odgovornost",
     ogImage: "https://novitalas.org/news/izbori-odgovornost.jpg",
     twitterTitle:
       "Nepravilnosti na izborima: zakon predviđa krivičnu odgovornost za manipulacije",
@@ -757,15 +767,15 @@ export const seoData: Record<string, SEOData> = {
   },
 
   "/nasa-planeta/artemis-ii-orion-polovina-puta-do-meseca": {
-    title:
-      "Orion više od polovine puta do Meseca | NOVI TALAS",
+    title: "Orion više od polovine puta do Meseca | NOVI TALAS",
     description:
       "Misija Artemis II nalazi se u dubokom svemiru nakon što je Orion prešao više od 160.000 kilometara od Zemlje.",
     ogTitle:
       "Orion više od polovine puta do Meseca: misija Artemis II u dubokom svemiru",
     ogDescription:
       "Misija Artemis II nalazi se u dubokom svemiru nakon što je Orion prešao više od 160.000 kilometara od Zemlje.",
-    ogUrl: "https://novitalas.org/nasa-planeta/artemis-ii-orion-polovina-puta-do-meseca",
+    ogUrl:
+      "https://novitalas.org/nasa-planeta/artemis-ii-orion-polovina-puta-do-meseca",
     ogImage: "https://novitalas.org/news/artemis-landing.jpg",
     twitterTitle:
       "Orion više od polovine puta do Meseca: misija Artemis II u dubokom svemiru",
@@ -841,7 +851,8 @@ export const seoData: Record<string, SEOData> = {
       "Fotografije iz dubokog svemira: Artemis II beleži prizore sa lunarnog preleta",
     ogDescription:
       "NASA objavila nove snimke Zemlje i pomračenja iz perspektive misije Artemis II.",
-    ogUrl: "https://novitalas.org/nasa-planeta/artemis-ii-fotografije-dubokog-svemira",
+    ogUrl:
+      "https://novitalas.org/nasa-planeta/artemis-ii-fotografije-dubokog-svemira",
     ogImage: "https://novitalas.org/news/orion-earth-view.jpg",
     twitterTitle:
       "Fotografije iz dubokog svemira: Artemis II beleži prizore sa lunarnog preleta",


### PR DESCRIPTION
### Motivation

- Publish a new Geopolitika article about the renewed US–Iran escalation with a hero-first Hormuz image and a two-part structure (informative chronology + broader geopolitical interpretation).
- Ensure the article is discoverable and indexable with full SEO metadata (title, description, OG/Twitter image, canonical, JSON-LD) and keywords for both static pre-render and runtime injection.
- Make the story the newest Geopolitika entry and promote it to the Home page hero while preserving existing site layout and templates.

### Description

- Added a new article page at `client/src/pages/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana.tsx` that implements the requested timeline and analysis, uses `/news/hormuz-chokepoint.jpg` as the hero, and sets `imageFirst={true}`.
- Registered the article route in `client/src/App.tsx` and made it the Home hero by updating `client/src/pages/Home.tsx` to point `HERO_ARTICLE` to the new path.
- Inserted the article as the first (newest) item in the Geopolitika index by updating `client/src/pages/GeopolitikaIndex.tsx`.
- Extended `ArticleTemplate` (`client/src/components/ArticleTemplate.tsx`) to support inline section headings (a new `heading` paragraph type) and preserved existing drop-cap, image-first layout, and styling.
- Added full SEO metadata for the article in `shared/seo.ts` (title, description, og/tweet image, `datePublished`, `author`, and comma-separated `keywords`).
- Pulled `keywords` through the SEO generation pipeline by updating `shared/articleMeta.ts`, `scripts/generate-seo-pages.ts`, `server/index.ts` and the client-side `SeoMeta` component (`client/src/components/SeoMeta.tsx`) so keywords are emitted in pre-rendered pages and injected at runtime.
- Ensured static SEO pages and sitemap generation include the new article by running the existing `generate-seo-pages` flow (no changes to its invocation semantics beyond keyword injection).
- Minor HTML / formatting tidy-ups in `client/index.html` to keep templates consistent with injected meta tags.

### Testing

- Ran formatting with `pnpm format`, which completed successfully.
- Type-check passed with `pnpm check` (`tsc --noEmit`), no errors reported after adjustments for `keywords` propagation.
- Production build succeeded with `pnpm build`; the static SEO pre-render step produced the article page and wrote the sitemap (the build log shows 115 SEO pages written and sitemap updated).
- Verified the generated pre-rendered article HTML contains the SEO title and `meta name="keywords"` entry using a search (`rg`) on `dist/public/.../index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5945a073e483258be6905abb2b8fa0)