### PR TITLE
Promote Serbian diplomacy article to homepage hero

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,29 +10,18 @@ import Footer from "@/components/Footer";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const HERO_ARTICLE = {
-  href: "/geopolitika/dva-moreuza-jedan-rat-sukob-sad-i-irana-ugrozava-svetske-energetske-puteve",
+  href: "/geopolitika/nova-orbita-srpske-diplomatije-zasto-se-beograd-priblizava-vasingtonu-bas-sada",
   category: "Geopolitika",
   title:
-    "Dva moreuza, jedan rat: sukob SAD i Irana ugrožava svetske energetske puteve",
+    "Nova orbita srpske diplomatije: zašto se Beograd približava Vašingtonu baš sada",
   description:
-    "Napad Huta na saudijske tankere u Crvenom moru otvorio je drugi front na putevima svetske nafte. Dok Iran gotovo zatvara Ormuski moreuz, njegov jemenski saveznik ugrožava Bab el Mandeb — prolaz kojim je Saudijska Arabija pokušavala da zaobiđe krizu u Persijskom zalivu.",
-  imageSrc: "/news/hormuz-bab-el-mandeb-energy-chokepoints.jpg",
+    "Dok Srbija prolazi kroz jednu od najdubljih društvenih i političkih kriza u poslednjoj deceniji, Beograd i Vašington otvaraju novo poglavlje međusobnih odnosa.",
+  imageSrc: "/news/serbia-artemis-accords.jpg",
   imageAlt:
-    "Grafička ilustracija dva ugrožena energetska prolaza, Ormuskog moreuza i Bab el Mandeba",
+    "Marko Đurić i zamenik administratora NASA Matt Anderson nakon potpisivanja sporazuma Artemis u sedištu NASA u Vašingtonu.",
 };
 
 const ARTICLES = [
-  {
-    href: "/geopolitika/nova-orbita-srpske-diplomatije-zasto-se-beograd-priblizava-vasingtonu-bas-sada",
-    category: "Geopolitika",
-    title:
-      "Nova orbita srpske diplomatije: zašto se Beograd približava Vašingtonu baš sada",
-    description:
-      "Dok Srbija prolazi kroz jednu od najdubljih društvenih i političkih kriza u poslednjoj deceniji, Beograd i Vašington otvaraju novo poglavlje međusobnih odnosa.",
-    imageSrc: "/news/serbia-artemis-accords.jpg",
-    imageAlt:
-      "Marko Đurić i zamenik administratora NASA Matt Anderson nakon potpisivanja sporazuma Artemis u sedištu NASA u Vašingtonu.",
-  },
   {
     href: "/geopolitika/od-primirja-do-novih-udara-kako-je-ponovo-eskalirao-sukob-sad-i-irana",
     category: "Geopolitika",


### PR DESCRIPTION
### Motivation
- Make the specified Geopolitika piece the main HERO article on the homepage using the supplied image. 
- Ensure the homepage keeps the same layout and design and that the article appears only once. 
- Preserve all existing secondary cards and leave the article page and Geopolitika ordering unchanged. 

### Description
- Updated the `HERO_ARTICLE` object in `client/src/pages/Home.tsx` to point to `/geopolitika/nova-orbita-srpske-diplomatije-zasto-se-beograd-priblizava-vasingtonu-bas-sada` and set the new `title`, `description`, `imageSrc` (`/news/serbia-artemis-accords.jpg`) and `imageAlt`.
- Removed the duplicate article entry from the `ARTICLES` array in `client/src/pages/Home.tsx` so the promoted article appears only once on the Home page. 
- Made no other content, article page, or Geopolitika index/order changes. 

### Testing
- Ran `pnpm exec prettier --write client/src/pages/Home.tsx` and formatting completed successfully. 
- Ran `pnpm check` (`tsc --noEmit`) and type checks passed. 
- Ran `pnpm build` and the production build and SEO pre-render generation completed successfully (the promoted article was included in prerendered pages). 
- Ran `git diff --check` and no diff-check issues were reported, and the homepage now contains the promoted article exactly once.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65fca5131c83258c34f2e3e35574d1)