### PR TITLE
Add Serbia without republic analysis

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -96,6 +96,7 @@ import KinaSpyBrodovi from "./pages/kina-spy-brodovi";
 import CiaPokrenulaKampanju from "./pages/cia-pokrenula-kampanju-za-regrutovanje-kineskih-vojnih-oficira";
 import PrviBrifing from "./pages/prvi-brifing";
 import SrbijaPage from "./pages/SrbijaPage";
+import SerbiaLostRepublicArticle from "./pages/SerbiaLostRepublicArticle";
 import SrbijaPolarizacija from "./pages/SrbijaPolarizacija";
 import SrbijaMarsZaPravosudje from "./pages/SrbijaMarsZaPravosudje";
 import PotpuniSlomVuciceveMedjunarodneReputacije from "./pages/potpuni-slom-vuciceve-medjunarodne-reputacije";
@@ -656,6 +657,10 @@ function Router() {
             SRBIJA
            ========================= */}
         <Route path="/srbija" component={SrbijaPage} />
+        <Route
+          path="/srbija/srbija-bez-republike-moze-li-se-obnoviti-drzava-posle-cetrnaest-godina-vlasti-sns-a"
+          component={SerbiaLostRepublicArticle}
+        />
 
         <Route
           path="/srbija/posle-slavije-vlast-ulazi-u-fazu-politicke-nervoze"

--- a/client/src/components/ArticleTemplate.tsx
+++ b/client/src/components/ArticleTemplate.tsx
@@ -4,6 +4,7 @@ import ImageCaption from "@/components/ImageCaption";
 import ShareButton from "@/components/ShareButton";
 import SeoMeta from "@/components/SeoMeta";
 import { useTheme } from "@/contexts/ThemeContext";
+import type { ReactNode } from "react";
 
 type ArticleInlineImage = {
   type: "image";
@@ -18,7 +19,16 @@ type ArticleSectionHeading = {
   text: string;
 };
 
-type ArticleParagraph = string | ArticleInlineImage | ArticleSectionHeading;
+type ArticleRichParagraph = {
+  type: "paragraph";
+  content: ReactNode;
+};
+
+type ArticleParagraph =
+  | string
+  | ArticleInlineImage
+  | ArticleSectionHeading
+  | ArticleRichParagraph;
 
 const EM_DASH_REPLACEMENT = ",";
 
@@ -232,6 +242,26 @@ export default function ArticleTemplate({
                   >
                     {p.text}
                   </h2>
+                ) : p.type === "paragraph" ? (
+                  <p
+                    className={
+                      idx === 0
+                        ? "text-[18px] md:text-[20px] leading-[1.75] first-letter:text-[64px] first-letter:font-bold first-letter:mr-2 first-letter:float-left first-letter:leading-[0.9]"
+                        : "mt-5 text-[17px] md:text-[18px] leading-[1.8]"
+                    }
+                    style={{
+                      fontFamily: "'Lora', serif",
+                      color: isDark
+                        ? idx === 0
+                          ? "#cfcac0"
+                          : "#b7b2aa"
+                        : idx === 0
+                          ? "#222"
+                          : "#333",
+                    }}
+                  >
+                    {p.content}
+                  </p>
                 ) : (
                   <figure
                     className="mt-5 border overflow-hidden"

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,18 +10,29 @@ import Footer from "@/components/Footer";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const HERO_ARTICLE = {
-  href: "/geopolitika/nova-orbita-srpske-diplomatije-zasto-se-beograd-priblizava-vasingtonu-bas-sada",
-  category: "Geopolitika",
+  href: "/srbija/srbija-bez-republike-moze-li-se-obnoviti-drzava-posle-cetrnaest-godina-vlasti-sns-a",
+  category: "Srbija · ANALIZA",
   title:
-    "Nova orbita srpske diplomatije: zašto se Beograd približava Vašingtonu baš sada",
+    "Srbija bez republike: može li se obnoviti država posle četrnaest godina vlasti SNS-a?",
   description:
-    "Dok Srbija prolazi kroz jednu od najdubljih društvenih i političkih kriza u poslednjoj deceniji, Beograd i Vašington otvaraju novo poglavlje međusobnih odnosa.",
-  imageSrc: "/news/serbia-artemis-accords.jpg",
+    "Rasprava o nepoverenju Vladi Srbije samo je povod za mnogo veće pitanje: šta se dogodilo sa zemljom u kojoj institucije potvrđuju političku volju oblikovanu izvan njih?",
+  imageSrc: "/news/lost-republic.jpg",
   imageAlt:
-    "Marko Đurić i zamenik administratora NASA Matt Anderson nakon potpisivanja sporazuma Artemis u sedištu NASA u Vašingtonu.",
+    "Minimalistička ilustracija kupole Narodne skupštine Srbije sa dugom senkom koja simbolizuje odnos između institucija i stvarne političke moći.",
 };
 
 const ARTICLES = [
+  {
+    href: "/geopolitika/nova-orbita-srpske-diplomatije-zasto-se-beograd-priblizava-vasingtonu-bas-sada",
+    category: "Geopolitika",
+    title:
+      "Nova orbita srpske diplomatije: zašto se Beograd približava Vašingtonu baš sada",
+    description:
+      "Dok Srbija prolazi kroz jednu od najdubljih društvenih i političkih kriza u poslednjoj deceniji, Beograd i Vašington otvaraju novo poglavlje međusobnih odnosa.",
+    imageSrc: "/news/serbia-artemis-accords.jpg",
+    imageAlt:
+      "Marko Đurić i zamenik administratora NASA Matt Anderson nakon potpisivanja sporazuma Artemis u sedištu NASA u Vašingtonu.",
+  },
   {
     href: "/nasa-planeta/planeta-ostaje-bez-daha-kiseonik-nestaje-iz-okeana-jezera-i-reka",
     category: "Naša planeta",
@@ -391,6 +402,7 @@ export default function Home() {
                 <div className="grid grid-cols-1 min-[420px]:grid-cols-2 gap-4">
                   <SmallArticleCard variant="tile" {...ARTICLES[3]} />
                   <SmallArticleCard variant="tile" {...ARTICLES[4]} />
+                  <SmallArticleCard variant="tile" {...ARTICLES[5]} />
                 </div>
               </div>
             </FadeIn>
@@ -465,6 +477,7 @@ export default function Home() {
               <section className="grid grid-cols-2 lg:grid-cols-3 gap-8">
                 <DesktopTileStory article={ARTICLES[3]} />
                 <DesktopTileStory article={ARTICLES[4]} />
+                <DesktopTileStory article={ARTICLES[5]} />
               </section>
             </FadeIn>
           </div>

--- a/client/src/pages/SerbiaLostRepublicArticle.tsx
+++ b/client/src/pages/SerbiaLostRepublicArticle.tsx
@@ -1,0 +1,181 @@
+import ArticleTemplate from "@/components/ArticleTemplate";
+
+const PATH =
+  "/srbija/srbija-bez-republike-moze-li-se-obnoviti-drzava-posle-cetrnaest-godina-vlasti-sns-a";
+
+export default function SerbiaLostRepublicArticle() {
+  return (
+    <ArticleTemplate
+      path={PATH}
+      sectionLabel="ANALIZA"
+      title="Srbija bez republike: može li se obnoviti država posle četrnaest godina vlasti SNS-a?"
+      dateLabel="28. JUL 2026."
+      deck="Rasprava o nepoverenju Vladi Srbije samo je povod za mnogo veće pitanje: šta se dogodilo sa zemljom u kojoj Vlada više nije stvarni centar izvršne vlasti, parlament ne kontroliše mesto na kojem se odluke donose, a institucije potvrđuju političku volju oblikovanu izvan njih?"
+      imageSrc="/news/lost-republic.jpg"
+      imageAlt="Minimalistička ilustracija kupole Narodne skupštine Srbije sa dugom senkom koja simbolizuje odnos između institucija i stvarne političke moći."
+      imageCredit="Vizual: Novi Talas / AI ilustracija"
+      imageFirst={true}
+      paragraphs={[
+        "Narodna skupština raspravlja o nepoverenju Vladi Srbije. Ishod je gotovo unapred poznat: vladajuća većina ima dovoljno glasova da Vlada opstane.",
+        {
+          type: "paragraph",
+          content: (
+            <>
+              Ali važnije pitanje nije da li će Vlada pasti, već{" "}
+              <strong>šta bi se njenim padom zaista promenilo</strong>.
+            </>
+          ),
+        },
+        "U parlamentarnoj republici Vlada je središte izvršne vlasti. Predsednik Vlade usmerava njen rad, ministri vode državnu politiku, a parlament ih kontroliše i poziva na odgovornost.",
+        "U Srbiji ta ustavna arhitektura formalno i dalje postoji. Postoje Vlada, Narodna skupština, sudovi, tužilaštva, regulatorna tela i izbori.",
+        "Ali Srbija već godinama ne funkcioniše kao republika definisana sopstvenim Ustavom.",
+        { type: "heading", text: "Vlada koja vlada samo formalno" },
+        "Današnja Vlada Srbije nije stvarni centar političkog odlučivanja.",
+        "Od predsednika Vlade javnost ne očekuje da odredi pravac spoljne politike, predstavi najvažnije državne projekte ili odgovori na veliku političku krizu. Ta očekivanja već godinama usmerena su prema predsedniku Republike, iako mu Ustav ne poverava upravljanje Vladom.",
+        "To nije samo posledica medijske dominacije jednog čoveka. Reč je o promeni stvarne strukture vlasti.",
+        "Ministri raspolažu budžetima, upravljaju administracijom, predlažu zakone i potpisuju odluke, ali njihova politička samostalnost prestaje tamo gde počinje volja predsedničkog i partijskog centra.",
+        {
+          type: "paragraph",
+          content: (
+            <>
+              Zato ministar može istovremeno biti moćan i politički nevažan.
+              Kada se neki projekat predstavlja kao uspeh, zasluga pripada
+              predsedniku. Kada nastane skandal, odgovornost se spušta naniže —
+              na ministra, direktora, komisiju ili službenika.
+            </>
+          ),
+        },
+        {
+          type: "paragraph",
+          content: (
+            <>
+              <strong>Moć je koncentrisana, a odgovornost raspršena.</strong>
+            </>
+          ),
+        },
+        "Promena ministra zato retko menja politiku. Menja se lice, ali ne i način odlučivanja.",
+        "Predlog za izglasavanje nepoverenja Vladi u sebi nosi paradoks: parlament pokušava da kontroliše organ kojem je ostavljena formalna odgovornost, ali ne i puna politička vlast.",
+        {
+          type: "heading",
+          text: "Institucije nisu nestale. Promenile su namenu",
+        },
+        "Republika nije samo naziv države.",
+        "Njena suština je u tome da vlast nije privatno vlasništvo pobednika i da se moć deli između institucija koje se međusobno ograničavaju.",
+        "Vlada upravlja, ali odgovara parlamentu. Predsednik predstavlja državu, ali ne upravlja svim njenim organima. Sudovi i tužilaštva postupaju bez političkog naloga. Mediji nadziru vlast u ime javnosti.",
+        "Takva ravnoteža u Srbiji nije ukinuta jednim zakonom. Razgrađivana je tokom četrnaest godina slabljenjem autonomije institucija i njihovim uklapanjem u jedinstvenu političku vertikalu.",
+        {
+          type: "paragraph",
+          content: (
+            <>
+              U tome se ogleda osnovna osobina sistema SNS-a:{" "}
+              <strong>
+                njegova autoritarnost nije nastala ukidanjem institucija, već
+                njihovim potčinjavanjem
+              </strong>
+              .
+            </>
+          ),
+        },
+        "Skupština je ostala, ali ne kontroliše stvarni centar izvršne vlasti.",
+        "Vlada je ostala, ali više nije glavno mesto odlučivanja.",
+        "Ministri su ostali, ali bez pune autonomije i odgovornosti.",
+        "Tužilaštva postoje, ali javnost ne može sa sigurnošću očekivati da se zakon jednako primenjuje prema običnom građaninu i prema politički moćnom pojedincu.",
+        "Izbori postoje, ali se održavaju u uslovima zloupotrebe javnih resursa, medijske neravnopravnosti i stapanja državne i partijske kampanje.",
+        "Institucije, dakle, nisu nestale.",
+        {
+          type: "paragraph",
+          content: (
+            <>
+              <strong>Promenile su namenu.</strong>
+            </>
+          ),
+        },
+        "Zarobljena institucija nije nužno neefikasna. Može biti stroga prema građaninu, a krajnje oprezna kada predmet dodirne politički vrh. Može brzo sprovesti odluku vlasti, ali godinama ne odgovoriti na pitanje javnosti.",
+        "Zbog toga nije sasvim tačno reći da sistem ne funkcioniše.",
+        "On često funkcioniše veoma disciplinovano.",
+        {
+          type: "paragraph",
+          content: (
+            <>
+              Pitanje je samo — <strong>u čiju korist</strong>.
+            </>
+          ),
+        },
+        { type: "heading", text: "Afera bez završetka" },
+        "Demokratske države nemaju manje skandala zato što su njihovi funkcioneri moralniji. Razlika je u tome što u demokratiji skandal proizvodi posledicu.",
+        "Ministar podnosi ostavku. Parlament pokreće istragu. Tužilaštvo postupa. Javnost dobija završetak: smenu, presudu, oslobađanje ili jasno obrazloženje.",
+        "U Srbiji je normalizovan drugačiji obrazac:",
+        "otkriće, negiranje, napad na izvor, relativizacija, delimična istraga, čekanje, nova afera.",
+        "Odgovornost se ne odbacuje uvek otvoreno. Ona se razlaže.",
+        "Jedan organ tvrdi da nije nadležan. Drugi čeka dokumentaciju. Treći vodi predistražni postupak. Predsednik saopštava svoju verziju događaja. Vladajuća većina kritiku proglašava napadom na državu.",
+        "Vreme prolazi, javnost se iscrpljuje, a novi slučaj potiskuje prethodni.",
+        "Sistem ne mora da dokaže da se zloupotreba nije dogodila.",
+        "Dovoljno je da joj ne dopusti politički i pravni epilog.",
+        "Tako afera prestaje da bude izuzetak. Ona postaje deo ritma države.",
+        "Sistem ne proizvodi samo poslušnost.",
+        "Proizvodi osećaj nepromenljivosti.",
+        { type: "heading", text: "Država kao infrastruktura partije" },
+        "Najdublja promena nije izvršena samo na vrhu vlasti.",
+        "Politička zavisnost proširena je kroz ministarstva, lokalne uprave, javna preduzeća, ustanove, konkurse, subvencije, medije i tokove javnog novca.",
+        "U mnogim sredinama partijska pripadnost postala je put do zaposlenja, napredovanja, ugovora sa državom ili zaštite od institucija.",
+        "Takav poredak ne održava se samo propagandom, već i mrežom materijalnih zavisnosti.",
+        "Vlast se zato ne brani samo političkim uverenjem.",
+        "Brani se radnim mestom.",
+        "Ugovorom.",
+        "Funkcijom.",
+        "Strahom od gubitka egzistencije.",
+        "Kada se partija tako duboko spoji sa državom, granica između javnog i partijskog interesa gotovo nestaje.",
+        "Partija se predstavlja kao država.",
+        "Kritika partije kao napad na Srbiju.",
+        "Promena vlasti kao opasnost po stabilnost zemlje.",
+        "Upravo tu republika gubi svoju osnovnu ideju: da država pripada svim građanima, bez obzira na to ko trenutno ima većinu.",
+        { type: "heading", text: "Najveća šteta SNS-a" },
+        "Četrnaest godina vlasti proizvelo je brojne afere, sumnje u korupciju, netransparentne poslove i slučajeve bez institucionalnog epiloga.",
+        "Ali najveća šteta ne može se izmeriti njihovim zbirom.",
+        "Najveća istorijska odgovornost vlasti SNS-a ogleda se u razgrađivanju demokratskog i republikanskog poretka Srbije.",
+        "U pretvaranju Vlade u izvršni servis neformalnog centra moći.",
+        "U svođenju ministara na potpisnike i branioce odluka koje nisu samostalno doneli.",
+        "U pretvaranju parlamenta u mesto na kojem se vlast potvrđuje, a ne kontroliše.",
+        "U potčinjavanju institucija koje bi morale da štite zakon.",
+        "U brisanju granice između partije i države.",
+        "U pretvaranju građanina iz nosioca suverenosti u posmatrača odluka donetih iznad njega.",
+        "To je najveći politički i istorijski prestup ove vlasti.",
+        "Koruptivna dela mogu biti istražena. Nezakoniti ugovori mogu biti raskinuti. Funkcioneri mogu biti procesuirani.",
+        "Ali mnogo je teže obnoviti sposobnost institucije da kaže „ne“ vlasti.",
+        "Još je teže obnoviti uverenje državnog službenika da služi zakonu, poslanika da odgovara građanima, a tužioca da mu za postupanje nije potreban politički signal.",
+        { type: "heading", text: "Obnova republike" },
+        "Promena vlasti neće sama po sebi obnoviti Srbiju.",
+        "Ali će otvoriti prostor da obnova počne.",
+        "Najvažniji test buduće vlasti neće biti da li ume da koristi aparat koji je nasledila, već da li ima snage da ga razgradi.",
+        "Da li će predsednik ostati u granicama ustavnih ovlašćenja?",
+        "Da li će Vlada ponovo stvarno upravljati državom?",
+        "Da li će parlament kontrolisati izvršnu vlast?",
+        "Da li će tužilac moći da istraži i bivšeg i novog ministra bez političke dozvole?",
+        "Da li će javno preduzeće prestati da bude partijski resurs?",
+        "SNS će jednog dana izgubiti vlast. Nijedna partija i nijedan predsednik nisu večni.",
+        "Ali izborna smena sama po sebi neće poništiti poslednjih četrnaest godina.",
+        "Prava promena počeće tek kada vlast ponovo bude podeljena, odgovornost jasno utvrđena, a institucije oslobođene obaveze da služe pobedniku.",
+        "Najveći zadatak buduće Srbije zato neće biti samo da smeni SNS.",
+        "Biće da obnovi republiku koju je sistem SNS-a ispraznio od njenog demokratskog sadržaja.",
+        {
+          type: "paragraph",
+          content: (
+            <>
+              <strong>Srbija ne mora ponovo da izmišlja demokratiju.</strong>
+            </>
+          ),
+        },
+        {
+          type: "paragraph",
+          content: (
+            <>
+              <strong>Mora da vrati državu njenim građanima.</strong>
+            </>
+          ),
+        },
+      ]}
+      backHref="/srbija"
+      backLabel="← Nazad na Srbiju"
+    />
+  );
+}

--- a/client/src/pages/SrbijaPage.tsx
+++ b/client/src/pages/SrbijaPage.tsx
@@ -11,6 +11,7 @@ import Footer from "@/components/Footer";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const IMAGES = {
+  lostRepublic: "/news/lost-republic.jpg",
   slomMedjunarodni: "/news/slom-medjunarodni.jpg",
   slavijaProtest: "/news/slavija-protest.jpg",
   iscezavanjeN1: "/news/iscezavanje-N1.jpg",
@@ -58,6 +59,62 @@ export default function SrbijaPage() {
 
           {/* LIST */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+            <article className="md:col-span-2">
+              <Link
+                href="/srbija/srbija-bez-republike-moze-li-se-obnoviti-drzava-posle-cetrnaest-godina-vlasti-sns-a"
+                className="no-underline"
+              >
+                <div
+                  className="border mb-4 overflow-hidden"
+                  style={{
+                    borderColor: isDark ? "#2a2a2e" : "#eee",
+                    backgroundColor: isDark ? "#1a1c22" : "#f7f7f7",
+                  }}
+                >
+                  <img
+                    src={IMAGES.lostRepublic}
+                    alt="Minimalistička ilustracija kupole Narodne skupštine Srbije sa dugom senkom koja simbolizuje odnos između institucija i stvarne političke moći."
+                    className="w-full h-[260px] md:h-[420px] object-cover object-center block"
+                    decoding="async"
+                  />
+                </div>
+
+                <span className="kicker">ANALIZA</span>
+                <h2
+                  className="mt-2 text-[26px] md:text-[34px] font-bold leading-[1.2]"
+                  style={{
+                    fontFamily: "'Playfair Display', serif",
+                    color: isDark ? "#e0ddd5" : "#111",
+                  }}
+                >
+                  Srbija bez republike: može li se obnoviti država posle
+                  četrnaest godina vlasti SNS-a?
+                </h2>
+
+                <p
+                  className="mt-2 text-[15px] leading-[1.6]"
+                  style={{
+                    fontFamily: "'Crimson Pro', serif",
+                    color: isDark ? "#9a978f" : "#555",
+                  }}
+                >
+                  Rasprava o nepoverenju Vladi Srbije otvara veće pitanje: šta
+                  se dogodilo sa zemljom u kojoj institucije potvrđuju političku
+                  volju oblikovanu izvan njih?
+                </p>
+
+                <div
+                  className="mt-3 text-[12px] font-semibold uppercase tracking-[0.08em]"
+                  style={{
+                    fontFamily: "'Source Sans 3', sans-serif",
+                    color: isDark ? "#d9bf7a" : "#8B0000",
+                  }}
+                >
+                  Otvori tekst →
+                </div>
+              </Link>
+            </article>
+
             <article>
               <Link
                 href="/srbija/potpuni-slom-vuciceve-medjunarodne-reputacije"
@@ -150,7 +207,10 @@ export default function SrbijaPage() {
                     color: isDark ? "#9a978f" : "#555",
                   }}
                 >
-                  Studentski pokret pokazuje sve jasnije obrise političke artikulacije, dok vlast istovremeno pokušava da kupi vreme i spreči formiranje studentske izborne liste čiji identitet još nije poznat javnosti.
+                  Studentski pokret pokazuje sve jasnije obrise političke
+                  artikulacije, dok vlast istovremeno pokušava da kupi vreme i
+                  spreči formiranje studentske izborne liste čiji identitet još
+                  nije poznat javnosti.
                 </p>
 
                 <div
@@ -193,7 +253,8 @@ export default function SrbijaPage() {
                     color: isDark ? "#e0ddd5" : "#111",
                   }}
                 >
-                  SENKE NAD EKRANOM: Tiho preuzimanje ili kontrolisano gašenje istine
+                  SENKE NAD EKRANOM: Tiho preuzimanje ili kontrolisano gašenje
+                  istine
                 </h2>
 
                 <p
@@ -203,7 +264,10 @@ export default function SrbijaPage() {
                     color: isDark ? "#9a978f" : "#555",
                   }}
                 >
-                  Proces pritiska na nezavisne medije retko je otvoren i nagao. Mnogo češće odvija se postepeno, kroz smene, promene uređivačke politike i sužavanje prostora javne reči. Slučaj N1 otvara pitanje granica takvog procesa u savremenom društvu.
+                  Proces pritiska na nezavisne medije retko je otvoren i nagao.
+                  Mnogo češće odvija se postepeno, kroz smene, promene
+                  uređivačke politike i sužavanje prostora javne reči. Slučaj N1
+                  otvara pitanje granica takvog procesa u savremenom društvu.
                 </p>
 
                 <div
@@ -246,7 +310,8 @@ export default function SrbijaPage() {
                     color: isDark ? "#e0ddd5" : "#111",
                   }}
                 >
-                  Nepravilnosti na izborima: zakon predviđa krivičnu odgovornost za manipulacije
+                  Nepravilnosti na izborima: zakon predviđa krivičnu odgovornost
+                  za manipulacije
                 </h2>
 
                 <p
@@ -256,8 +321,9 @@ export default function SrbijaPage() {
                     color: isDark ? "#9a978f" : "#555",
                   }}
                 >
-                  Prijavljene nepravilnosti tokom izbora u Srbiji otvaraju pitanje
-                  krivične odgovornosti za manipulacije i zloupotrebe izbornog procesa.
+                  Prijavljene nepravilnosti tokom izbora u Srbiji otvaraju
+                  pitanje krivične odgovornosti za manipulacije i zloupotrebe
+                  izbornog procesa.
                 </p>
 
                 <div
@@ -274,10 +340,7 @@ export default function SrbijaPage() {
 
             {/* NOVA VEST — Rezultati izbora */}
             <article>
-              <Link
-                href="/srbija/izbori-rezultati"
-                className="no-underline"
-              >
+              <Link href="/srbija/izbori-rezultati" className="no-underline">
                 <div
                   className="border mb-4 overflow-hidden"
                   style={{
@@ -300,7 +363,8 @@ export default function SrbijaPage() {
                     color: isDark ? "#e0ddd5" : "#111",
                   }}
                 >
-                  Tesne razlike i smanjenje prednosti vlasti: preliminarni rezultati u deset opština
+                  Tesne razlike i smanjenje prednosti vlasti: preliminarni
+                  rezultati u deset opština
                 </h2>
 
                 <p
@@ -310,7 +374,9 @@ export default function SrbijaPage() {
                     color: isDark ? "#9a978f" : "#555",
                   }}
                 >
-                  Preliminarni rezultati lokalnih izbora u deset opština u Srbiji: vladajuća koalicija zadržala vlast uz vidljivo smanjene razlike i tesne odnose snaga.
+                  Preliminarni rezultati lokalnih izbora u deset opština u
+                  Srbiji: vladajuća koalicija zadržala vlast uz vidljivo
+                  smanjene razlike i tesne odnose snaga.
                 </p>
 
                 <div
@@ -381,10 +447,7 @@ export default function SrbijaPage() {
 
             {/* NOVA ANALIZA — Akademija umetnosti Novi Sad */}
             <article>
-              <Link
-                href="/srbija/akademija-novisad"
-                className="no-underline"
-              >
+              <Link href="/srbija/akademija-novisad" className="no-underline">
                 <div
                   className="border mb-4 overflow-hidden"
                   style={{
@@ -407,7 +470,8 @@ export default function SrbijaPage() {
                     color: isDark ? "#e0ddd5" : "#111",
                   }}
                 >
-                  Grad odlučuje, studenti na ulici: Akademiji umetnosti preti gubitak prostora
+                  Grad odlučuje, studenti na ulici: Akademiji umetnosti preti
+                  gubitak prostora
                 </h2>
 
                 <p
@@ -418,8 +482,8 @@ export default function SrbijaPage() {
                   }}
                 >
                   Odbornici odlučuju o oduzimanju prostora Akademiji umetnosti u
-                  Novom Sadu, dok studenti i profesori protestuju i upozoravaju na
-                  posledice.
+                  Novom Sadu, dok studenti i profesori protestuju i upozoravaju
+                  na posledice.
                 </p>
 
                 <div
@@ -582,9 +646,9 @@ export default function SrbijaPage() {
                     color: isDark ? "#9a978f" : "#555",
                   }}
                 >
-                  Blokade su završene, ali poljoprivrednici odlaze sa protesta bez
-                  dogovora sa državom, što otvara pitanje političkih posledica u
-                  zemlji čiju stabilnost vekovima nosi selo.
+                  Blokade su završene, ali poljoprivrednici odlaze sa protesta
+                  bez dogovora sa državom, što otvara pitanje političkih
+                  posledica u zemlji čiju stabilnost vekovima nosi selo.
                 </p>
 
                 <div
@@ -625,8 +689,8 @@ export default function SrbijaPage() {
                     color: isDark ? "#e0ddd5" : "#111",
                   }}
                 >
-                  Marš za pravosuđe: kada institucije postanu centralno političko
-                  pitanje
+                  Marš za pravosuđe: kada institucije postanu centralno
+                  političko pitanje
                 </h2>
 
                 <p
@@ -636,8 +700,8 @@ export default function SrbijaPage() {
                     color: isDark ? "#9a978f" : "#555",
                   }}
                 >
-                  Kada sudovi postanu tema politike, društvo raspravlja o sopstvenom
-                  ustavnom identitetu i o granicama izvršne vlasti.
+                  Kada sudovi postanu tema politike, društvo raspravlja o
+                  sopstvenom ustavnom identitetu i o granicama izvršne vlasti.
                 </p>
 
                 <div

--- a/shared/articleMeta.ts
+++ b/shared/articleMeta.ts
@@ -148,6 +148,15 @@ export function buildJsonLd(meta: {
  */
 export const articleMeta: ArticleStaticMeta[] = [
   {
+    path: "/srbija/srbija-bez-republike-moze-li-se-obnoviti-drzava-posle-cetrnaest-godina-vlasti-sns-a",
+    title:
+      "Srbija bez republike: može li se obnoviti država posle četrnaest godina vlasti SNS-a?",
+    description:
+      "Politički esej o transformaciji institucija Srbije tokom četrnaest godina vlasti SNS-a i pitanju može li se obnoviti republika u ustavnom smislu.",
+    imageSrc: "/news/lost-republic.jpg",
+    datePublished: "2026-07-28",
+  },
+  {
     path: "/geopolitika/nova-orbita-srpske-diplomatije-zasto-se-beograd-priblizava-vasingtonu-bas-sada",
     title:
       "Nova orbita srpske diplomatije: zašto se Beograd približava Vašingtonu baš sada",


### PR DESCRIPTION
### Motivation
- Add a new long-form Serbia analysis article and integrate it into the existing article flow (article page, Srbija index card, Home HERO, and SEO) following the repository's established patterns. 
- Ensure the hero image, deck, routing, and shared metadata are correctly registered so the article appears in the Home hero, Serbia index, and social/OG previews. 
- Preserve the provided text verbatim (headings, Serbian diacritics, bold emphasis, punctuation and em dashes) while avoiding any redesign of the article system.

### Description
- Create `client/src/pages/SerbiaLostRepublicArticle.tsx` using the existing `ArticleTemplate` with `imageFirst={true}` and the supplied article content, image, alt text and credit. 
- Register the new route in `client/src/App.tsx` at `/srbija/srbija-bez-republike-moze-li-se-obnoviti-drzava-posle-cetrnaest-godina-vlasti-sns-a` and import the new page component. 
- Promote the article to the main Home hero by updating `client/src/pages/Home.tsx` (new HERO_ARTICLE values) while keeping the previous hero in the secondary positions, and insert the article as the first prominent card in `client/src/pages/SrbijaPage.tsx`. 
- Add the article's SEO/OG metadata entry to `shared/articleMeta.ts` with `imageSrc`, `description` and `datePublished`, and extend `client/src/components/ArticleTemplate.tsx` to accept a small rich-paragraph variant (`ArticleRichParagraph`) so inline React content (bold emphasis and preserved em dashes) renders verbatim without changing the template architecture.

### Testing
- Ran `pnpm exec prettier --write` on the modified files and formatting succeeded. 
- Ran `pnpm check` (`tsc --noEmit`) and the TypeScript checks passed. 
- Ran `pnpm build` and the production build completed and the static SEO prerenderer produced the new article page (the build emitted non-blocking warnings about analytics environment variables and large chunk sizes but finished successfully). 
- Ran `git diff --check` and standard repository checks passed (no remaining diff errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68eb56fa948325913538451bae1204)