### PR TITLE
Add CRISPR long-form article to Naša planeta, register route, update Home hero and SEO metadata

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -251,6 +251,7 @@ import VespaRome80Article from "./pages/VespaRome80Article";
 import AlexandriaLighthouseArticle from "./pages/AlexandriaLighthouseArticle";
 import PolMakartniSaRolingstonsimaArticle from "./pages/pol-makartni-sa-rolingstonsima-na-novom-albumu-koji-izlazi-10-jula";
 import PlanetaOstajeBezDahaArticle from "./pages/planeta-ostaje-bez-daha-kiseonik-nestaje-iz-okeana-jezera-i-reka";
+import RevolucijaUBorbiProtivRakaCrisprArticle from "./pages/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora";
 
 /* ✅ NOVA VEST — Naša planeta */
 import NasaAnounce from "./pages/nasa-anounce";
@@ -719,6 +720,11 @@ function Router() {
         {/* =========================
             NAŠA PLANETA
            ========================= */}
+        <Route
+          path="/nasa-planeta/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora"
+          component={RevolucijaUBorbiProtivRakaCrisprArticle}
+        />
+
         <Route
           path="/nasa-planeta/planeta-ostaje-bez-daha-kiseonik-nestaje-iz-okeana-jezera-i-reka"
           component={PlanetaOstajeBezDahaArticle}

--- a/client/src/components/SeoMeta.tsx
+++ b/client/src/components/SeoMeta.tsx
@@ -146,6 +146,7 @@ export default function SeoMeta({
             ogImage,
             datePublished: registered.datePublished,
             author: registered.author,
+            section: registered.section,
           })
         );
       } else if (title) {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,18 +10,29 @@ import Footer from "@/components/Footer";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const HERO_ARTICLE = {
-  href: "/srbija/srbija-bez-republike-moze-li-se-obnoviti-drzava-posle-cetrnaest-godina-vlasti-sns-a",
-  category: "Srbija · ANALIZA",
+  href: "/nasa-planeta/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora",
+  category: "Naša planeta",
   title:
-    "Srbija bez republike: može li se obnoviti država posle četrnaest godina vlasti SNS-a?",
+    "Revolucija u borbi protiv raka: CRISPR koji ne popravlja gene, već uništava ćelije tumora",
   description:
-    "Rasprava o nepoverenju Vladi Srbije samo je povod za mnogo veće pitanje: šta se dogodilo sa zemljom u kojoj institucije potvrđuju političku volju oblikovanu izvan njih?",
-  imageSrc: "/news/lost-republic.jpg",
+    "Nova istraživanja otvaraju mogućnost da se CRISPR tehnologija koristi ne samo za ispravljanje gena već i za selektivno uništavanje obolelih ćelija. Iako je put do терапије за пацијенте још дуг, научници говоре о новом правцу у развоју прецизнијих метода лечења рака.",
+  imageSrc: "/news/    crispr-cancer-therapy.jpg",
   imageAlt:
-    "Minimalistička ilustracija kupole Narodne skupštine Srbije sa dugom senkom koja simbolizuje odnos između institucija i stvarne političke moći.",
+    "Mikroskopska ilustracija tumorske ćelije koju napada precizno usmerena CRISPR terapija.",
 };
 
 const ARTICLES = [
+  {
+    href: "/srbija/srbija-bez-republike-moze-li-se-obnoviti-drzava-posle-cetrnaest-godina-vlasti-sns-a",
+    category: "Srbija · ANALIZA",
+    title:
+      "Srbija bez republike: može li se obnoviti država posle četrnaest godina vlasti SNS-a?",
+    description:
+      "Rasprava o nepoverenju Vladi Srbije samo je povod za mnogo veće pitanje: šta se dogodilo sa zemljom u kojoj institucije potvrđuju političku volju oblikovanu izvan njih?",
+    imageSrc: "/news/lost-republic.jpg",
+    imageAlt:
+      "Minimalistička ilustracija kupole Narodne skupštine Srbije sa dugom senkom koja simbolizuje odnos između institucija i stvarne političke moći.",
+  },
   {
     href: "/geopolitika/nova-orbita-srpske-diplomatije-zasto-se-beograd-priblizava-vasingtonu-bas-sada",
     category: "Geopolitika",
@@ -74,17 +85,6 @@ const ARTICLES = [
     imageSrc: "/news/paul-mccartney-rolling-stones.jpg",
     imageAlt:
       "Ilustracija Pola Makartnija i Mika Džegera povodom nove saradnje na albumu Foreign Tongues.",
-  },
-  {
-    href: "/nasa-planeta/jedno-od-sedam-svetskih-cuda-ponovo-otkriva-svoje-tajne-aleksandrijski-svetionik-izrasta-iz-mora",
-    category: "Naša planeta",
-    title:
-      "Jedno od sedam svetskih čuda ponovo otkriva svoje tajne: Aleksandrijski svetionik izranja iz mora",
-    description:
-      "Arheolozi su iz Sredozemnog mora izvadili monumentalne kamene blokove nekadašnjeg Aleksandrijskog svetionika, otvarajući put ka njegovoj najpreciznijoj digitalnoj rekonstrukciji do sada.",
-    imageSrc: "/news/alexandria-lighthouse-underwater-ruins.jpg",
-    imageAlt:
-      "Conceptual underwater illustration inspired by the archaeological remains of the Lighthouse of Alexandria",
   },
 ];
 

--- a/client/src/pages/NasaPlanetaIndex.tsx
+++ b/client/src/pages/NasaPlanetaIndex.tsx
@@ -19,6 +19,16 @@ type NasaPlanetaArticle = {
 
 const ARTICLES: NasaPlanetaArticle[] = [
   {
+    href: "/nasa-planeta/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora",
+    img: "/news/    crispr-cancer-therapy.jpg",
+    alt: "Mikroskopska ilustracija tumorske ćelije koju napada precizno usmerena CRISPR terapija.",
+    imageCredit: "Ilustracija: Novi talas",
+    title:
+      "Revolucija u borbi protiv raka: CRISPR koji ne popravlja gene, već uništava ćelije tumora",
+    description:
+      "Nova istraživanja otvaraju mogućnost da se CRISPR tehnologija koristi ne samo za ispravljanje gena već i za selektivno uništavanje obolelih ćelija. Iako je put do терапије за пацијенте још дуг, научници говоре о новом правцу у развоју прецизнијих метода лечења рака.",
+  },
+  {
     href: "/nasa-planeta/planeta-ostaje-bez-daha-kiseonik-nestaje-iz-okeana-jezera-i-reka",
     img: "/news/ocean-deep.jpg",
     alt: "Bleached coral on the seabed beneath a thinning school of fish, symbolizing the global loss of oxygen from aquatic ecosystems.",

--- a/client/src/pages/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora.tsx
+++ b/client/src/pages/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora.tsx
@@ -1,0 +1,63 @@
+import ArticleTemplate from "@/components/ArticleTemplate";
+
+const PATH =
+  "/nasa-planeta/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora";
+
+const PARAGRAPHS = [
+  "Napredak u genskoj medicini dugo je počivao na jednoj velikoj ideji: pronaći grešku u genetskom kodu i popraviti je. Nova generacija CRISPR sistema mogla bi, međutim, da promeni samu logiku tog pristupa.",
+  "Umesto popravljanja gena u oboleloj ćeliji, istraživači ispituju mogućnost da se precizno prepozna opasna genetska promena i pokrene uništavanje ćelije koja je nosi. Takav pristup mogao bi da otvori novo poglavlje u borbi protiv raka — naročito kod tumora čije je mutacije teško ili nemoguće direktno ispraviti postojećim metodama.",
+  {
+    type: "heading" as const,
+    text: "Od genetskih makaza do ćelijskog prekidača",
+  },
+  "CRISPR je javnosti najpoznatiji kao sistem „genetskih makaza“: molekularni alat koji može da pronađe određeni deo DNK, preseče ga i omogući njegovu izmenu. Ta tehnologija već je promenila biološka istraživanja i otvorila put prvim genskim terapijama.",
+  "Novi pravac istraživanja ide korak dalje. Pojedini CRISPR sistemi, kada prepoznaju zadatu genetsku metu, ne deluju samo na jednu precizno određenu tačku. Njihova aktivacija može da izazove šire oštećenje genetskog materijala i dovede do smrti ćelije.",
+  "U laboratorijskim uslovima to svojstvo može da se pretvori u prednost: sistem se programira tako da reaguje samo kada naiđe na molekularni znak karakterističan za obolelu ćeliju. Zdrave ćelije, koje taj znak nemaju, trebalo bi da ostanu pošteđene.",
+  "Time CRISPR više ne bi služio isključivo za ispravljanje genetske greške. Postao bi i svojevrsni molekularni prekidač koji uklanja ćeliju u kojoj je prepoznata opasna promena.",
+  {
+    type: "heading" as const,
+    text: "Zašto je ova ideja važna za lečenje raka",
+  },
+  "Rak nije jedna bolest, već velika grupa bolesti nastalih zbog različitih promena u genima koji regulišu rast, deobu i opstanak ćelija. Neke od tih promena moguće je napasti postojećim lekovima, dok su druge decenijama ostajale izvan domašaja medicine.",
+  "Poseban problem predstavljaju mutacije koje podstiču nekontrolisano razmnožavanje ćelija, ali nemaju lako dostupnu strukturu za koju bi se lek mogao vezati. U takvim slučajevima nije dovoljno znati koja mutacija izaziva bolest — potrebno je pronaći način da se upravo ćelija sa tom mutacijom selektivno ukloni.",
+  "Tu se nalazi najveći potencijal novog pristupa. Umesto pokušaja da se svaki oštećeni gen popravi ili blokira posebnim lekom, CRISPR sistem mogao bi da bude programiran da prepozna genetski potpis tumorske ćelije i aktivira njen mehanizam uništenja.",
+  "U teoriji, takva terapija mogla bi da bude veoma precizna. Njena meta ne bi bila određena samo mestom na kojem se tumor nalazi već njegovim jedinstvenim molekularnim karakteristikama.",
+  { type: "heading" as const, text: "Najveći izazov ostaje preciznost" },
+  "Između uspešnog laboratorijskog eksperimenta i terapije koja se bezbedno koristi kod ljudi nalazi se veliki broj prepreka.",
+  "Prva je način unošenja CRISPR sistema u organizam. Molekularni alat mora da stigne do dovoljnog broja tumorskih ćelija, a da pritom ne izazove neželjenu reakciju imunskog sistema i ne ošteti zdrava tkiva.",
+  "Druga prepreka je sama raznolikost tumora. Ćelije unutar jednog tumora nisu uvek genetski identične. Terapija usmerena na jednu mutaciju mogla bi da uništi veliki deo tumora, ali da poštedi ćelije koje tu mutaciju nemaju.",
+  "Treći izazov jeste kontrola aktivnosti sistema. Mehanizam koji može da izazove masovno oštećenje genetskog materijala mora biti izuzetno precizno usmeren. Svaka neželjena aktivacija u zdravoj ćeliji predstavljala bi ozbiljan bezbednosni rizik.",
+  "Zbog toga će biti potrebna opsežna ispitivanja pre nego što se može govoriti o primeni kod pacijenata. Rezultati dobijeni na ćelijskim kulturama ili eksperimentalnim modelima ne znače automatski da će isti pristup biti efikasan i bezbedan u ljudskom organizmu.",
+  { type: "heading" as const, text: "Nova paradigma precizne medicine" },
+  "Uprkos ograničenjima, promena koju ova istraživanja nagoveštavaju mogla bi biti velika.",
+  "Prva generacija precizne onkologije pokušavala je da pronađe lek za određenu mutaciju. Nova generacija mogla bi da programira biološki sistem koji tu mutaciju sam prepoznaje i uklanja ćeliju u kojoj se ona nalazi.",
+  "To ne znači da će hemoterapija, radioterapija, hirurgija ili imunoterapija postati suvišne. Mnogo je verovatnije da bi se CRISPR pristupi jednog dana koristili zajedno sa postojećim metodama — kao dodatno oružje protiv tumora koji se vraćaju, razvijaju otpornost ili ne odgovaraju na standardno lečenje.",
+  "Najveća promena možda neće biti u jednom konkretnom leku, već u načinu na koji se terapija osmišljava. Umesto univerzalnog napada na sve ćelije koje se brzo dele, lečenje bi se sve više zasnivalo na molekularnom identitetu svake bolesti.",
+  {
+    type: "heading" as const,
+    text: "Oprez između naučnog proboja i kliničke primene",
+  },
+  "Istorija medicine puna je otkrića koja su u laboratoriji izgledala revolucionarno, ali nisu uspela da postanu bezbedne i delotvorne terapije. Zbog toga je važno razlikovati naučni potencijal od dokazane kliničke koristi.",
+  "Nova istraživanja još ne predstavljaju lek protiv raka. Ona pokazuju da CRISPR može imati širu ulogu nego što se ranije pretpostavljalo — ne samo da menja genetski kod već i da selektivno uklanja ćelije na osnovu njihove genetske osobenosti.",
+  "Ako istraživači uspeju da reše problem precizne isporuke, bezbednosti i raznolikosti tumora, ova tehnologija mogla bi da postane deo nove generacije personalizovanih terapija.",
+  "Revolucija, dakle, još nije stigla u bolnice. Ali ideja koja je pokreće već menja granice mogućeg: umesto da pokušava da popravi svaku opasno izmenjenu ćeliju, medicina bi jednog dana mogla da je prepozna — i ukloni pre nego što bolest nastavi da se širi.",
+];
+
+export default function RevolucijaUBorbiProtivRakaCrisprArticle() {
+  return (
+    <ArticleTemplate
+      path={PATH}
+      sectionLabel="Naša planeta"
+      title="Revolucija u borbi protiv raka: CRISPR koji ne popravlja gene, već uništava ćelije tumora"
+      dateLabel="29. jul 2026."
+      deck="Nova istraživanja otvaraju mogućnost da se CRISPR tehnologija koristi ne samo za ispravljanje gena već i za selektivno uništavanje obolelih ćelija. Iako je put do терапије за пацијенте још дуг, научници говоре о новом правцу у развоју прецизнијих метода лечења рака."
+      imageSrc="/news/    crispr-cancer-therapy.jpg"
+      imageAlt="Mikroskopska ilustracija tumorske ćelije koju napada precizno usmerena CRISPR terapija."
+      imageCredit="Ilustracija: Novi talas"
+      imageFirst={true}
+      paragraphs={PARAGRAPHS}
+      backHref="/nasa-planeta"
+      backLabel="← Nazad na Našu planetu"
+    />
+  );
+}

--- a/scripts/generate-seo-pages.ts
+++ b/scripts/generate-seo-pages.ts
@@ -172,6 +172,7 @@ function injectSEO(
     ogImage: resolvedSeo.ogImage,
     datePublished: resolvedSeo.datePublished,
     author: resolvedSeo.author,
+    section: resolvedSeo.section,
   });
   const jsonLdScript = `  <script type="application/ld+json">\n    ${JSON.stringify(jsonLdData, null, 2).replace(/\n/g, "\n    ")}\n  </script>`;
   result = result.replace(/(<\/body>)/, `${jsonLdScript}\n  $1`);

--- a/server/index.ts
+++ b/server/index.ts
@@ -139,6 +139,7 @@ function injectSEO(html: string, route: string): string {
     ogImage: seo.ogImage,
     datePublished: seo.datePublished,
     author: seo.author,
+    section: seo.section,
   });
   const jsonLdScript = `  <script type="application/ld+json">\n    ${JSON.stringify(jsonLdData, null, 2).replace(/\n/g, "\n    ")}\n  </script>`;
   result = result.replace(/(<\/body>)/, `${jsonLdScript}\n  $1`);

--- a/shared/articleMeta.ts
+++ b/shared/articleMeta.ts
@@ -38,8 +38,10 @@ export interface ArticleStaticMeta {
    * Used for JSON-LD datePublished and og:article:published_time.
    */
   datePublished?: string;
-  /** Article author name. Defaults to "Novi Talas" if omitted. */
+  /** Article author name. Omitted from metadata when not provided. */
   author?: string;
+  /** Editorial section used by Article JSON-LD. */
+  section?: string;
   /** Comma-separated article keywords for search engines that use the tag. */
   keywords?: string;
 }
@@ -67,6 +69,7 @@ export function buildSEOFromArticleMeta(meta: ArticleStaticMeta) {
     twitterImage: ogImage,
     datePublished: meta.datePublished,
     author: meta.author,
+    section: meta.section,
     keywords: meta.keywords,
   };
 }
@@ -101,8 +104,8 @@ export function buildJsonLd(meta: {
   ogImage: string;
   datePublished?: string;
   author?: string;
+  section?: string;
 }) {
-  const authorName = meta.author ?? "Novi Talas";
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const jsonLd: Record<string, any> = {
     "@context": "https://schema.org",
@@ -110,13 +113,6 @@ export function buildJsonLd(meta: {
     headline: meta.title,
     description: meta.description,
     image: [meta.ogImage],
-    author: [
-      {
-        "@type": authorName === "Novi Talas" ? "Organization" : "Person",
-        name: authorName,
-        url: SITE_BASE,
-      },
-    ],
     publisher: {
       "@type": "Organization",
       name: "Novi Talas",
@@ -133,6 +129,20 @@ export function buildJsonLd(meta: {
     },
   };
 
+  if (meta.author) {
+    jsonLd["author"] = [
+      {
+        "@type": meta.author === "Novi Talas" ? "Organization" : "Person",
+        name: meta.author,
+        url: SITE_BASE,
+      },
+    ];
+  }
+
+  if (meta.section) {
+    jsonLd["articleSection"] = meta.section;
+  }
+
   if (meta.datePublished) {
     jsonLd["datePublished"] = `${meta.datePublished}T00:00:00+01:00`;
   }
@@ -147,6 +157,20 @@ export function buildJsonLd(meta: {
  * produce the correct static HTML / HTTP response with full OG + Twitter tags.
  */
 export const articleMeta: ArticleStaticMeta[] = [
+  {
+    path: "/nasa-planeta/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora",
+    title:
+      "Revolucija u borbi protiv raka: CRISPR koji ne popravlja gene, već uništava ćelije tumora",
+    seoTitle:
+      "Revolucija u borbi protiv raka: CRISPR koji ne popravlja gene, već uništava ćelije tumora | Novi Talas",
+    description:
+      "Nova istraživanja otvaraju mogućnost da se CRISPR koristi ne samo za uređivanje gena već i za selektivno uništavanje tumorskih ćelija, čime se otvara novi pravac u razvoju precizних терапија против рака.",
+    imageSrc: "/news/    crispr-cancer-therapy.jpg",
+    datePublished: "2026-07-29",
+    section: "Naša planeta",
+    keywords:
+      "CRISPR, rak, tumorske ćelije, genska medicina, precizna medicina, personalizovane terapije, Naša planeta, Novi Talas",
+  },
   {
     path: "/srbija/srbija-bez-republike-moze-li-se-obnoviti-drzava-posle-cetrnaest-godina-vlasti-sns-a",
     title:


### PR DESCRIPTION
### Motivation
- Publish a new long-form article in the existing `Naša planeta` section using the existing `ArticleTemplate` and follow the established routing, metadata and Home ordering conventions. 
- Ensure the article uses the already-uploaded lead image and that the same image is used for Home hero, section card and all OG/Twitter metadata.
- Make the new article the Home HERO and move the previous HERO into the first secondary slot while preserving the Home layout and the relative order of other secondary articles. 
- Provide full static and runtime SEO metadata (Open Graph, Twitter, canonical, published date, JSON-LD) while omitting any author/byline.

### Description
- Added a dedicated article component `client/src/pages/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora.tsx` that uses `ArticleTemplate` with `imageFirst={true}` and includes the complete supplied Serbian article text and headings exactly as provided. 
- Promoted the new CRISPR article to the Home hero in `client/src/pages/Home.tsx`, moved the former hero object to become the first item of the secondary `ARTICLES` array, and preserved the other five secondary articles and their relative order; removed the Alexandria Lighthouse entry only from the Home selection. 
- Inserted the new article as the first (featured) entry in `client/src/pages/NasaPlanetaIndex.tsx` and registered its canonical route in `client/src/App.tsx` at `/nasa-planeta/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora`. 
- Added a minimal SEO entry in `shared/articleMeta.ts` and extended JSON-LD handling to include the article `section` where present; updated `client/src/components/SeoMeta.tsx`, `server/index.ts` and `scripts/generate-seo-pages.ts` to include `section` in structured data. 
- Used the exact existing image file discovered in the repo root `client/public/news` with filename `    crispr-cancer-therapy.jpg` and public path `/news/    crispr-cancer-therapy.jpg` (exact spacing preserved) for the article lead image, Home hero, section card and OG/Twitter metadata. 
- Created and modified files: created `client/src/pages/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora.tsx`; modified `client/src/pages/Home.tsx`, `client/src/pages/NasaPlanetaIndex.tsx`, `client/src/App.tsx`, `shared/articleMeta.ts`, `client/src/components/SeoMeta.tsx`, `server/index.ts`, and `scripts/generate-seo-pages.ts`.

### Testing
- Ran the project formatter with `pnpm exec prettier --write ...` on the modified files and the files were formatted successfully. 
- Ran `pnpm check` (TypeScript `tsc --noEmit`) and the type check passed with no errors. 
- Ran `pnpm build` which completed successfully and the static SEO generation wrote pre-rendered pages including the new article (`/nasa-planeta/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora`) to `dist/public`; the build produced non-blocking warnings about large chunks but finished successfully. 
- Ran `git diff --check` and no whitespace/patch errors remain; static SEO output and generated HTML include canonical link, meta description, OG/Twitter tags, published date and JSON-LD `articleSection`, and the JSON-LD does not include an article `author` when none was provided.
- Note: a headless browser screenshot/visual check could not be captured because a browser executable is not available in the environment, but route, Home ordering, section index ordering and pre-rendered SEO files were verified via the build and static outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69fb56a9ac83259f7f562bd57a1f95)