### PR TITLE
Hitno: vratiti CRISPR članak na srpsku latinicu

### DIFF
--- a/client/src/pages/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora.tsx
+++ b/client/src/pages/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora.tsx
@@ -50,7 +50,7 @@ export default function RevolucijaUBorbiProtivRakaCrisprArticle() {
       sectionLabel="Naša planeta"
       title="Revolucija u borbi protiv raka: CRISPR koji ne popravlja gene, već uništava ćelije tumora"
       dateLabel="29. jul 2026."
-      deck="Nova istraživanja otvaraju mogućnost da se CRISPR tehnologija koristi ne samo za ispravljanje gena već i za selektivno uništavanje obolelih ćelija. Iako je put do терапије за пацијенте још дуг, научници говоре о новом правцу у развоју прецизнијих метода лечења рака."
+      deck="Nova istraživanja otvaraju mogućnost da se CRISPR tehnologija koristi ne samo za ispravljanje gena već i za selektivno uništavanje obolelih ćelija. Iako je put do terapije za pacijente još dug, naučnici govore o novom pravcu u razvoju preciznijih metoda lečenja raka."
       imageSrc="/news/    crispr-cancer-therapy.jpg"
       imageAlt="Mikroskopska ilustracija tumorske ćelije koju napada precizno usmerena CRISPR terapija."
       imageCredit="Ilustracija: Novi talas"


### PR DESCRIPTION
### Motivation
- Hitna ispravka zbog prijava čitalaca — u uvodnom decku članka se pojavio jedini ćirilični segment koji je napravio mešovito pismo i mora biti vraćen u srpsku latinicu bez promene smisla ili ostalih meta-podataka.

### Description
- Zamenjen je jedini ćirilični segment u `client/src/pages/revolucija-u-borbi-protiv-raka-crispr-koji-ne-popravlja-gene-vec-unistava-celije-tumora.tsx` decka transliteracijom u latinicu (Cyrillic → Latin), bez menjanja naslova, rute, slike, SEO ili drugih članaka; izmene su commitovane kao `e5fbc2a63cbdcfcd34ca1fc90f8fa8cb85e54d8c`.

### Testing
- Pokrenuti su `pnpm exec prettier --write`, `pnpm check`, `pnpm build` i `git diff --check`, kao i skripta za Unicode proveru koja potvrđuje `0` ćiriličnih karaktera u datoteci, i svi automatski testovi/provere su prošli uspešno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c66fc6ed08325a3a5a4963df048ec)