### PR TITLE
Add Danube nuclear crisis as latest Geopolitika feature

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -255,6 +255,7 @@ import RevolucijaUBorbiProtivRakaCrisprArticle from "./pages/revolucija-u-borbi-
 import FrontierAiSlowdownArticle from "./pages/FrontierAiSlowdownArticle";
 import VanishingStarsArticle from "./pages/VanishingStarsArticle";
 import CeutaMigrationCrisisArticle from "./pages/CeutaMigrationCrisisArticle";
+import DanubeNuclearCrisisArticle from "./pages/DanubeNuclearCrisisArticle";
 
 /* ✅ NOVA VEST — Naša planeta */
 import NasaAnounce from "./pages/nasa-anounce";
@@ -294,6 +295,10 @@ function Router() {
         {/* =========================
             GEOPOLITIKA
            ========================= */}
+        <Route
+          path="/geopolitika/istorijska-susa-ugrozila-nuklearne-elektrane-na-dunavu-rumunija-minira-stenovite-prepreke-madjarska-gasi-reaktore"
+          component={DanubeNuclearCrisisArticle}
+        />
         <Route
           path="/geopolitika/zasto-je-desetine-hiljada-ljudi-krenulo-ka-spaniji-kriza-u-seuti-otvara-nova-pitanja-o-granicama-evrope"
           component={CeutaMigrationCrisisArticle}

--- a/client/src/pages/DanubeNuclearCrisisArticle.tsx
+++ b/client/src/pages/DanubeNuclearCrisisArticle.tsx
@@ -1,0 +1,32 @@
+import ArticleTemplate from "@/components/ArticleTemplate";
+
+const PATH =
+  "/geopolitika/istorijska-susa-ugrozila-nuklearne-elektrane-na-dunavu-rumunija-minira-stenovite-prepreke-madjarska-gasi-reaktore";
+
+const PARAGRAPHS = [
+  "Rekordno nizak vodostaj Dunava, izazvan dugotrajnom sušom i talasom ekstremnih vrućina, prerastao je u ozbiljan energetski problem za jugoistočnu Evropu. Dve države koje veliki deo električne energije dobijaju iz nuklearnih elektrana hlađenih vodom iz Dunava – Rumunija i Mađarska – prinuđene su na vanredne mere kako bi sprečile poremećaje u snabdevanju električnom energijom.",
+  "Rumunske vlasti naredile su kontrolisano miniranje stenovitih prepreka u koritu Dunava kako bi povećale dotok vode ka nuklearnoj elektrani Černavoda. Cilj ove operacije jeste izgradnja privremene brane koja bi obezbedila dovoljno rashladne vode za reaktor koji je ostao u pogonu, nakon što je drugi već ranije isključen zbog istorijski niskog vodostaja.",
+  "Istovremeno, u Mađarskoj je nuklearna elektrana Paks, koja proizvodi gotovo polovinu električne energije u zemlji, svela proizvodnju na minimum. Vlasti upozoravaju da bi, ukoliko se nivo Dunava dodatno smanji, elektrana mogla prvi put za više od četiri decenije potpuno da obustavi rad.",
+  "Kako bi rasteretile elektroenergetske mreže, obe države pozvale su građane i privredu da smanje potrošnju električne energije. U Rumuniji su pojedini veliki industrijski pogoni, među kojima su fabrike kompanija Dacia i Ford, privremeno obustavili proizvodnju kako bi deo raspoložive električne energije ostao na raspolaganju domaćinstvima i kritičnoj infrastrukturi.",
+  "Posledice rekordne suše osećaju se širom regiona. Nizak vodostaj otežava plovidbu Dunavom, usporava transport robe i smanjuje proizvodnju hidroelektrana, dok meteorološke prognoze za sada ne najavljuju značajnije padavine koje bi mogle da poprave stanje.",
+  "Događaji na Dunavu pokazuju koliko klimatski ekstremi mogu da promene funkcionisanje evropske energetike. Reka koja povezuje deset država postala je jedan od ključnih oslonaca energetske bezbednosti regiona, jer od njenog vodostaja danas zavisi rad nuklearnih elektrana, plovidba i stabilnost elektroenergetskih sistema. Svaki novi dan bez ozbiljnijih padavina povećava rizik od novih ograničenja u proizvodnji električne energije i dodatnog pritiska na privredu širom srednje i jugoistočne Evrope.",
+];
+
+export default function DanubeNuclearCrisisArticle() {
+  return (
+    <ArticleTemplate
+      path={PATH}
+      sectionLabel="Geopolitika"
+      title="Istorijska suša ugrozila nuklearne elektrane na Dunavu: Rumunija minira stenovite prepreke, Mađarska gasi reaktore"
+      dateLabel="3. avgust 2026."
+      deck="Rekordno nizak vodostaj Dunava primorao je Rumuniju i Mađarsku na vanredne mere kako bi zaštitile rad svojih nuklearnih elektrana i očuvale stabilnost elektroenergetskih sistema."
+      imageSrc="/news/danube-slankamen.jpg"
+      imageAlt="Panoramski pogled na Dunav kod Starog Slankamena."
+      imageCredit="Foto: Lukder / Wikimedia Commons (CC BY-SA 4.0)"
+      imageFirst={true}
+      paragraphs={PARAGRAPHS}
+      backHref="/geopolitika"
+      backLabel="← Nazad na Geopolitiku"
+    />
+  );
+}

--- a/client/src/pages/GeopolitikaIndex.tsx
+++ b/client/src/pages/GeopolitikaIndex.tsx
@@ -18,6 +18,15 @@ type Article = {
 
 const ARTICLES: Article[] = [
   {
+    href: "/geopolitika/istorijska-susa-ugrozila-nuklearne-elektrane-na-dunavu-rumunija-minira-stenovite-prepreke-madjarska-gasi-reaktore",
+    title:
+      "Istorijska suša ugrozila nuklearne elektrane na Dunavu: Rumunija minira stenovite prepreke, Mađarska gasi reaktore",
+    description:
+      "Rekordno nizak vodostaj Dunava primorao je Rumuniju i Mađarsku na vanredne mere kako bi zaštitile rad svojih nuklearnih elektrana i očuvale stabilnost elektroenergetskih sistema.",
+    imageSrc: "/news/danube-slankamen.jpg",
+    imageAlt: "Panoramski pogled na Dunav kod Starog Slankamena.",
+  },
+  {
     href: "/geopolitika/zasto-je-desetine-hiljada-ljudi-krenulo-ka-spaniji-kriza-u-seuti-otvara-nova-pitanja-o-granicama-evrope",
     title:
       "Zašto je desetine hiljada ljudi krenulo ka Španiji? Kriza u Seuti otvara nova pitanja o granicama Evrope",

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,18 +10,28 @@ import Footer from "@/components/Footer";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const HERO_ARTICLE = {
-  href: "/geopolitika/zasto-je-desetine-hiljada-ljudi-krenulo-ka-spaniji-kriza-u-seuti-otvara-nova-pitanja-o-granicama-evrope",
+  href: "/geopolitika/istorijska-susa-ugrozila-nuklearne-elektrane-na-dunavu-rumunija-minira-stenovite-prepreke-madjarska-gasi-reaktore",
   category: "Geopolitika",
   title:
-    "Zašto je desetine hiljada ljudi krenulo ka Španiji? Kriza u Seuti otvara nova pitanja o granicama Evrope",
+    "Istorijska suša ugrozila nuklearne elektrane na Dunavu: Rumunija minira stenovite prepreke, Mađarska gasi reaktore",
   description:
-    "Posle najvećeg migrantskog talasa u novijoj istoriji Seute, Španija pooštrava kontrolu granice, dok Evropa ponovo otvara raspravu o zaštiti svojih spoljašnjih granica i migrantskoj politici.",
-  imageSrc: "/news/ceuta-border-fence.jpg",
-  imageAlt:
-    "Granična ograda koja razdvaja špansku enklavu Seutu od teritorije Maroka.",
+    "Rekordno nizak vodostaj Dunava primorao je Rumuniju i Mađarsku na vanredne mere kako bi zaštitile rad svojih nuklearnih elektrana i očuvale stabilnost elektroenergetskih sistema.",
+  imageSrc: "/news/danube-slankamen.jpg",
+  imageAlt: "Panoramski pogled na Dunav kod Starog Slankamena.",
 };
 
 const ARTICLES = [
+  {
+    href: "/geopolitika/zasto-je-desetine-hiljada-ljudi-krenulo-ka-spaniji-kriza-u-seuti-otvara-nova-pitanja-o-granicama-evrope",
+    category: "Geopolitika",
+    title:
+      "Zašto je desetine hiljada ljudi krenulo ka Španiji? Kriza u Seuti otvara nova pitanja o granicama Evrope",
+    description:
+      "Posle najvećeg migrantskog talasa u novijoj istoriji Seute, Španija pooštrava kontrolu granice, dok Evropa ponovo otvara raspravu o zaštiti svojih spoljašnjih granica i migrantskoj politici.",
+    imageSrc: "/news/ceuta-border-fence.jpg",
+    imageAlt:
+      "Granična ograda koja razdvaja špansku enklavu Seutu od teritorije Maroka.",
+  },
   {
     href: "/nasa-planeta/ko-ce-ugasiti-zvezde-astronomi-upozoravaju-da-bi-17-miliona-satelita-moglo-trajno-da-promeni-nocno-nebo",
     category: "Naša planeta",
@@ -75,16 +85,6 @@ const ARTICLES = [
     imageSrc: "/news/serbia-artemis-accords.jpg",
     imageAlt:
       "Marko Đurić i zamenik administratora NASA Matt Anderson nakon potpisivanja sporazuma Artemis u sedištu NASA u Vašingtonu.",
-  },
-  {
-    href: "/nasa-planeta/planeta-ostaje-bez-daha-kiseonik-nestaje-iz-okeana-jezera-i-reka",
-    category: "Naša planeta",
-    title: "Planeta ostaje bez daha: kiseonik nestaje iz okeana, jezera i reka",
-    description:
-      "Novo međunarodno istraživanje pokazuje da količina rastvorenog kiseonika ubrzano opada u okeanima, morima, rekama i jezerima, što predstavlja jednu od najvećih pretnji vodenim ekosistemima i budućnosti života na Zemlji.",
-    imageSrc: "/news/ocean-deep.jpg",
-    imageAlt:
-      "Bleached coral on the seabed beneath a thinning school of fish, symbolizing the global loss of oxygen from aquatic ecosystems.",
   },
 ];
 

--- a/shared/articleMeta.ts
+++ b/shared/articleMeta.ts
@@ -158,6 +158,18 @@ export function buildJsonLd(meta: {
  */
 export const articleMeta: ArticleStaticMeta[] = [
   {
+    path: "/geopolitika/istorijska-susa-ugrozila-nuklearne-elektrane-na-dunavu-rumunija-minira-stenovite-prepreke-madjarska-gasi-reaktore",
+    title:
+      "Istorijska suša ugrozila nuklearne elektrane na Dunavu: Rumunija minira stenovite prepreke, Mađarska gasi reaktore",
+    seoTitle:
+      "Istorijska suša ugrozila nuklearne elektrane na Dunavu: Rumunija minira stenovite prepreke, Mađarska gasi reaktore | Novi Talas",
+    description:
+      "Rekordno nizak vodostaj Dunava primorao je Rumuniju i Mađarsku na vanredne mere kako bi zaštitile rad nuklearnih elektrana i stabilnost energetskog sistema.",
+    imageSrc: "/news/danube-slankamen.jpg",
+    section: "Geopolitika",
+    datePublished: "2026-08-03",
+  },
+  {
     path: "/geopolitika/zasto-je-desetine-hiljada-ljudi-krenulo-ka-spaniji-kriza-u-seuti-otvara-nova-pitanja-o-granicama-evrope",
     title:
       "Zašto je desetine hiljada ljudi krenulo ka Španiji? Kriza u Seuti otvara nova pitanja o granicama Evrope",


### PR DESCRIPTION
### Motivation
- Publish a new Geopolitika feature about the Danube nuclear crisis using the existing article pattern and ArticleTemplate without changing design or other articles. 
- Register the article route and ensure the story appears as the Home hero and as the first item in the Geopolitika listing with correct image and metadata.

### Description
- Add `client/src/pages/DanubeNuclearCrisisArticle.tsx` that uses `ArticleTemplate` with `imageFirst={true}`, the exact provided title, deck, full article paragraphs, `dateLabel` "3. avgust 2026.", image `/news/danube-slankamen.jpg`, alt text and credit; no author field is added.
- Register the new route in `client/src/App.tsx` and import the component so the article is reachable at the provided path.
- Insert the article as the first entry in `client/src/pages/GeopolitikaIndex.tsx` and promote it to `HERO_ARTICLE` in `client/src/pages/Home.tsx`, moving the previous hero into the first secondary slot and removing the oldest secondary item to keep the same count.
- Register full SEO/share metadata in `shared/articleMeta.ts` including `seoTitle`, `description`, `imageSrc`, `section: "Geopolitika"` and `datePublished: "2026-08-03"`.

### Testing
- Ran `pnpm exec prettier --write .` which completed successfully.
- Ran `pnpm check` (`tsc --noEmit`) which passed with no type errors.
- Ran `pnpm build` which completed and pre-rendered SEO pages (including the new route); build emitted non-fatal warnings about chunk size and missing env vars but finished successfully and wrote static pages to `dist/public/`.
- Ran `git diff --check` and no diff-check issues were reported; changes committed under SHA `9e528d1c02b7180504dda8d8cd930477c234cfc9`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70f92c74a08325a69a5db576473283)